### PR TITLE
Documentation updates

### DIFF
--- a/docusaurus/docs/atomic-angular/components/filters/filter-button.md
+++ b/docusaurus/docs/atomic-angular/components/filters/filter-button.md
@@ -20,10 +20,6 @@ The `FilterButtonComponent` represents an individual filter as a button, allowin
 
 <img src={useBaseUrl('img/components/filter-button.png')} class="card" alt='filters bar' />
 
-:::tip
-The height of the dropdown can be adjusted using the [`--agg-max-height`](/mint/configurations/css-variables#aggregation-variables) CSS variable.
-:::
-
 ## API Reference
 
 ### Inputs

--- a/docusaurus/docs/changelog.md
+++ b/docusaurus/docs/changelog.md
@@ -15,6 +15,6 @@ handling of lists that exceed the visible area in a vertical layout.
 
 ### ✨ Updates
 
-* [preview](services/preview.md): Enhanced the preview service to support custom highlights and improved interaction with the preview iframe.
-* [Aggregations service](services/aggregations.md): Updated to include methods for loading more aggregation items and opening aggregation nodes.  
-* [App store](stores/app): Updated documentation to clarify the use of [`getAuthorizedFilters`](stores/app#getauthorizedfilters) for retrieving sorted aggregations based on a query name and added missing methods.
+* [preview](atomic-angular/services/preview.md): Enhanced the preview service to support custom highlights and improved interaction with the preview iframe.
+* [Aggregations service](atomic-angular/services/aggregations.md): Updated to include methods for loading more aggregation items and opening aggregation nodes.
+* [App store](atomic-angular/stores/app.mdx): Updated documentation to clarify the use of [`getAuthorizedFilters`](atomic-angular/stores/app.mdx#getauthorizedfilters) for retrieving sorted aggregations based on a query name and added missing methods.


### PR DESCRIPTION
This commit addresses two documentation issues:
- The `changelog.md` file's internal links for services and stores have been updated to correctly point to their respective `atomic-angular` documentation paths. This ensures all references are accurate and functional.
- An irrelevant tip regarding the `--agg-max-height` CSS variable has been removed from the `filter-button.md` documentation. This improves the accuracy and relevance of the component's documentation.