### PR TITLE
#noJiraCheck chore: use npmjs registry instead of npm.sinequa.com in lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -87,7 +87,7 @@
     },
     "node_modules/@algolia/abtesting": {
       "version": "1.1.0",
-      "resolved": "https://npm.sinequa.com/@algolia/abtesting/-/abtesting-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.1.0.tgz",
       "integrity": "sha512-sEyWjw28a/9iluA37KLGu8vjxEIlb60uxznfTUmXImy7H5NvbpSO6yYgmgH5KiD7j+zTUUihiST0jEP12IoXow==",
       "dev": true,
       "license": "MIT",
@@ -103,7 +103,7 @@
     },
     "node_modules/@algolia/client-abtesting": {
       "version": "5.35.0",
-      "resolved": "https://npm.sinequa.com/@algolia/client-abtesting/-/client-abtesting-5.35.0.tgz",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.35.0.tgz",
       "integrity": "sha512-uUdHxbfHdoppDVflCHMxRlj49/IllPwwQ2cQ8DLC4LXr3kY96AHBpW0dMyi6ygkn2MtFCc6BxXCzr668ZRhLBQ==",
       "dev": true,
       "license": "MIT",
@@ -119,7 +119,7 @@
     },
     "node_modules/@algolia/client-analytics": {
       "version": "5.35.0",
-      "resolved": "https://npm.sinequa.com/@algolia/client-analytics/-/client-analytics-5.35.0.tgz",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.35.0.tgz",
       "integrity": "sha512-SunAgwa9CamLcRCPnPHx1V2uxdQwJGqb1crYrRWktWUdld0+B2KyakNEeVn5lln4VyeNtW17Ia7V7qBWyM/Skw==",
       "dev": true,
       "license": "MIT",
@@ -135,7 +135,7 @@
     },
     "node_modules/@algolia/client-common": {
       "version": "5.35.0",
-      "resolved": "https://npm.sinequa.com/@algolia/client-common/-/client-common-5.35.0.tgz",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.35.0.tgz",
       "integrity": "sha512-ipE0IuvHu/bg7TjT2s+187kz/E3h5ssfTtjpg1LbWMgxlgiaZIgTTbyynM7NfpSJSKsgQvCQxWjGUO51WSCu7w==",
       "dev": true,
       "license": "MIT",
@@ -145,7 +145,7 @@
     },
     "node_modules/@algolia/client-insights": {
       "version": "5.35.0",
-      "resolved": "https://npm.sinequa.com/@algolia/client-insights/-/client-insights-5.35.0.tgz",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.35.0.tgz",
       "integrity": "sha512-UNbCXcBpqtzUucxExwTSfAe8gknAJ485NfPN6o1ziHm6nnxx97piIbcBQ3edw823Tej2Wxu1C0xBY06KgeZ7gA==",
       "dev": true,
       "license": "MIT",
@@ -161,7 +161,7 @@
     },
     "node_modules/@algolia/client-personalization": {
       "version": "5.35.0",
-      "resolved": "https://npm.sinequa.com/@algolia/client-personalization/-/client-personalization-5.35.0.tgz",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.35.0.tgz",
       "integrity": "sha512-/KWjttZ6UCStt4QnWoDAJ12cKlQ+fkpMtyPmBgSS2WThJQdSV/4UWcqCUqGH7YLbwlj3JjNirCu3Y7uRTClxvA==",
       "dev": true,
       "license": "MIT",
@@ -177,7 +177,7 @@
     },
     "node_modules/@algolia/client-query-suggestions": {
       "version": "5.35.0",
-      "resolved": "https://npm.sinequa.com/@algolia/client-query-suggestions/-/client-query-suggestions-5.35.0.tgz",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.35.0.tgz",
       "integrity": "sha512-8oCuJCFf/71IYyvQQC+iu4kgViTODbXDk3m7yMctEncRSRV+u2RtDVlpGGfPlJQOrAY7OONwJlSHkmbbm2Kp/w==",
       "dev": true,
       "license": "MIT",
@@ -193,7 +193,7 @@
     },
     "node_modules/@algolia/client-search": {
       "version": "5.35.0",
-      "resolved": "https://npm.sinequa.com/@algolia/client-search/-/client-search-5.35.0.tgz",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.35.0.tgz",
       "integrity": "sha512-FfmdHTrXhIduWyyuko1YTcGLuicVbhUyRjO3HbXE4aP655yKZgdTIfMhZ/V5VY9bHuxv/fGEh3Od1Lvv2ODNTg==",
       "dev": true,
       "license": "MIT",
@@ -209,7 +209,7 @@
     },
     "node_modules/@algolia/ingestion": {
       "version": "1.35.0",
-      "resolved": "https://npm.sinequa.com/@algolia/ingestion/-/ingestion-1.35.0.tgz",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.35.0.tgz",
       "integrity": "sha512-gPzACem9IL1Co8mM1LKMhzn1aSJmp+Vp434An4C0OBY4uEJRcqsLN3uLBlY+bYvFg8C8ImwM9YRiKczJXRk0XA==",
       "dev": true,
       "license": "MIT",
@@ -225,7 +225,7 @@
     },
     "node_modules/@algolia/monitoring": {
       "version": "1.35.0",
-      "resolved": "https://npm.sinequa.com/@algolia/monitoring/-/monitoring-1.35.0.tgz",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.35.0.tgz",
       "integrity": "sha512-w9MGFLB6ashI8BGcQoVt7iLgDIJNCn4OIu0Q0giE3M2ItNrssvb8C0xuwJQyTy1OFZnemG0EB1OvXhIHOvQwWw==",
       "dev": true,
       "license": "MIT",
@@ -241,7 +241,7 @@
     },
     "node_modules/@algolia/recommend": {
       "version": "5.35.0",
-      "resolved": "https://npm.sinequa.com/@algolia/recommend/-/recommend-5.35.0.tgz",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.35.0.tgz",
       "integrity": "sha512-AhrVgaaXAb8Ue0u2nuRWwugt0dL5UmRgS9LXe0Hhz493a8KFeZVUE56RGIV3hAa6tHzmAV7eIoqcWTQvxzlJeQ==",
       "dev": true,
       "license": "MIT",
@@ -257,7 +257,7 @@
     },
     "node_modules/@algolia/requester-browser-xhr": {
       "version": "5.35.0",
-      "resolved": "https://npm.sinequa.com/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.35.0.tgz",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.35.0.tgz",
       "integrity": "sha512-diY415KLJZ6x1Kbwl9u96Jsz0OstE3asjXtJ9pmk1d+5gPuQ5jQyEsgC+WmEXzlec3iuVszm8AzNYYaqw6B+Zw==",
       "dev": true,
       "license": "MIT",
@@ -270,7 +270,7 @@
     },
     "node_modules/@algolia/requester-fetch": {
       "version": "5.35.0",
-      "resolved": "https://npm.sinequa.com/@algolia/requester-fetch/-/requester-fetch-5.35.0.tgz",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.35.0.tgz",
       "integrity": "sha512-uydqnSmpAjrgo8bqhE9N1wgcB98psTRRQXcjc4izwMB7yRl9C8uuAQ/5YqRj04U0mMQ+fdu2fcNF6m9+Z1BzDQ==",
       "dev": true,
       "license": "MIT",
@@ -283,7 +283,7 @@
     },
     "node_modules/@algolia/requester-node-http": {
       "version": "5.35.0",
-      "resolved": "https://npm.sinequa.com/@algolia/requester-node-http/-/requester-node-http-5.35.0.tgz",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.35.0.tgz",
       "integrity": "sha512-RgLX78ojYOrThJHrIiPzT4HW3yfQa0D7K+MQ81rhxqaNyNBu4F1r+72LNHYH/Z+y9I1Mrjrd/c/Ue5zfDgAEjQ==",
       "dev": true,
       "license": "MIT",
@@ -296,7 +296,7 @@
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
-      "resolved": "https://npm.sinequa.com/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
       "license": "MIT",
       "engines": {
@@ -308,7 +308,7 @@
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
-      "resolved": "https://npm.sinequa.com/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
       "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -321,7 +321,7 @@
     },
     "node_modules/@angular-architects/ngrx-toolkit": {
       "version": "20.4.2",
-      "resolved": "https://npm.sinequa.com/@angular-architects/ngrx-toolkit/-/ngrx-toolkit-20.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/@angular-architects/ngrx-toolkit/-/ngrx-toolkit-20.4.2.tgz",
       "integrity": "sha512-Nqe6sKN1pUozds9+EE53i2G8PeMZfc4Ki6ba/FOzEtJMQ1/MhDRm3utJ/ox9KwSPoWPxDNdj8oILUVvrm1e8yw==",
       "license": "MIT",
       "dependencies": {
@@ -342,7 +342,7 @@
     },
     "node_modules/@angular-devkit/architect": {
       "version": "0.2003.22",
-      "resolved": "https://npm.sinequa.com/@angular-devkit/architect/-/architect-0.2003.22.tgz",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2003.22.tgz",
       "integrity": "sha512-gxVOslVweD+Co6gpRVlByHus/3HVAnsl99MobS9PBh8vh2g6bJ011PBgl0TKsP/pqBGawZOkJXYrRPeMKnobYA==",
       "dev": true,
       "license": "MIT",
@@ -358,7 +358,7 @@
     },
     "node_modules/@angular-devkit/core": {
       "version": "20.3.22",
-      "resolved": "https://npm.sinequa.com/@angular-devkit/core/-/core-20.3.22.tgz",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-20.3.22.tgz",
       "integrity": "sha512-1vZnZTAjGcCM+86v2al+2eiROiSw0uAWeVllfHSQe0KsKOP1FE8UUUiWChhxVn7vIxypphlfGunkeeIn1C/ZFw==",
       "dev": true,
       "license": "MIT",
@@ -386,7 +386,7 @@
     },
     "node_modules/@angular-devkit/schematics": {
       "version": "20.3.22",
-      "resolved": "https://npm.sinequa.com/@angular-devkit/schematics/-/schematics-20.3.22.tgz",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-20.3.22.tgz",
       "integrity": "sha512-gN2XSXRn3eErGEJlH0iSfQZZ7NdxVZNdjSxuVEGBEFhe3cVeC21LzM3GTWW6xwtBb4pxHglFyc7BUFiYtZiYtg==",
       "dev": true,
       "license": "MIT",
@@ -405,7 +405,7 @@
     },
     "node_modules/@angular-devkit/schematics/node_modules/chalk": {
       "version": "5.6.2",
-      "resolved": "https://npm.sinequa.com/chalk/-/chalk-5.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "dev": true,
       "license": "MIT",
@@ -418,14 +418,14 @@
     },
     "node_modules/@angular-devkit/schematics/node_modules/emoji-regex": {
       "version": "10.6.0",
-      "resolved": "https://npm.sinequa.com/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@angular-devkit/schematics/node_modules/is-interactive": {
       "version": "2.0.0",
-      "resolved": "https://npm.sinequa.com/is-interactive/-/is-interactive-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
       "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
       "dev": true,
       "license": "MIT",
@@ -438,7 +438,7 @@
     },
     "node_modules/@angular-devkit/schematics/node_modules/is-unicode-supported": {
       "version": "2.1.0",
-      "resolved": "https://npm.sinequa.com/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
       "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
       "dev": true,
       "license": "MIT",
@@ -451,7 +451,7 @@
     },
     "node_modules/@angular-devkit/schematics/node_modules/log-symbols": {
       "version": "6.0.0",
-      "resolved": "https://npm.sinequa.com/log-symbols/-/log-symbols-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
       "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
       "dev": true,
       "license": "MIT",
@@ -468,7 +468,7 @@
     },
     "node_modules/@angular-devkit/schematics/node_modules/log-symbols/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "resolved": "https://npm.sinequa.com/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
       "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
       "dev": true,
       "license": "MIT",
@@ -481,7 +481,7 @@
     },
     "node_modules/@angular-devkit/schematics/node_modules/ora": {
       "version": "8.2.0",
-      "resolved": "https://npm.sinequa.com/ora/-/ora-8.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
       "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
       "dev": true,
       "license": "MIT",
@@ -505,7 +505,7 @@
     },
     "node_modules/@angular-devkit/schematics/node_modules/string-width": {
       "version": "7.2.0",
-      "resolved": "https://npm.sinequa.com/string-width/-/string-width-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "dev": true,
       "license": "MIT",
@@ -523,7 +523,7 @@
     },
     "node_modules/@angular/animations": {
       "version": "20.3.15",
-      "resolved": "https://npm.sinequa.com/@angular/animations/-/animations-20.3.15.tgz",
+      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-20.3.15.tgz",
       "integrity": "sha512-ikyKfhkxoqQA6JcBN0B9RaN6369sM1XYX81Id0lI58dmWCe7gYfrTp8ejqxxKftl514psQO3pkW8Gn1nJ131Gw==",
       "license": "MIT",
       "dependencies": {
@@ -538,7 +538,7 @@
     },
     "node_modules/@angular/build": {
       "version": "20.3.22",
-      "resolved": "https://npm.sinequa.com/@angular/build/-/build-20.3.22.tgz",
+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-20.3.22.tgz",
       "integrity": "sha512-sxjVZU6AZHXyKRHJUMawXOj4qMf3vm8XK6wUejr01UKj6BqW2YWaQO26RpRJssXD2ITTqn6+UBwL7pEwe2a4Jg==",
       "dev": true,
       "license": "MIT",
@@ -637,7 +637,7 @@
     },
     "node_modules/@angular/build/node_modules/ansi-styles": {
       "version": "6.2.3",
-      "resolved": "https://npm.sinequa.com/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "dev": true,
       "license": "MIT",
@@ -650,14 +650,14 @@
     },
     "node_modules/@angular/build/node_modules/emoji-regex": {
       "version": "10.6.0",
-      "resolved": "https://npm.sinequa.com/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@angular/build/node_modules/listr2": {
       "version": "9.0.1",
-      "resolved": "https://npm.sinequa.com/listr2/-/listr2-9.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.1.tgz",
       "integrity": "sha512-SL0JY3DaxylDuo/MecFeiC+7pedM0zia33zl0vcjgwcq1q1FWWF1To9EIauPbl8GbMCU0R2e0uJ8bZunhYKD2g==",
       "dev": true,
       "license": "MIT",
@@ -675,7 +675,7 @@
     },
     "node_modules/@angular/build/node_modules/semver": {
       "version": "7.7.2",
-      "resolved": "https://npm.sinequa.com/semver/-/semver-7.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
@@ -688,7 +688,7 @@
     },
     "node_modules/@angular/build/node_modules/string-width": {
       "version": "7.2.0",
-      "resolved": "https://npm.sinequa.com/string-width/-/string-width-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "dev": true,
       "license": "MIT",
@@ -706,7 +706,7 @@
     },
     "node_modules/@angular/build/node_modules/wrap-ansi": {
       "version": "9.0.2",
-      "resolved": "https://npm.sinequa.com/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
       "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
       "dev": true,
       "license": "MIT",
@@ -724,7 +724,7 @@
     },
     "node_modules/@angular/cdk": {
       "version": "20.2.14",
-      "resolved": "https://npm.sinequa.com/@angular/cdk/-/cdk-20.2.14.tgz",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-20.2.14.tgz",
       "integrity": "sha512-7bZxc01URbiPiIBWThQ69XwOxVduqEKN4PhpbF2AAyfMc/W8Hcr4VoIJOwL0O1Nkq5beS8pCAqoOeIgFyXd/kg==",
       "license": "MIT",
       "dependencies": {
@@ -739,7 +739,7 @@
     },
     "node_modules/@angular/cli": {
       "version": "20.3.22",
-      "resolved": "https://npm.sinequa.com/@angular/cli/-/cli-20.3.22.tgz",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-20.3.22.tgz",
       "integrity": "sha512-0uyQPF0gGuzioWJKNyOzWSQrrC5GiidR+8gz1lODoJTnJZZdsP5n3nvccbcRmhy55B1WByHvQBE+6eDBbh06/g==",
       "dev": true,
       "license": "MIT",
@@ -774,7 +774,7 @@
     },
     "node_modules/@angular/cli/node_modules/ansi-styles": {
       "version": "6.2.3",
-      "resolved": "https://npm.sinequa.com/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "dev": true,
       "license": "MIT",
@@ -787,7 +787,7 @@
     },
     "node_modules/@angular/cli/node_modules/cliui": {
       "version": "9.0.1",
-      "resolved": "https://npm.sinequa.com/cliui/-/cliui-9.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
       "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
       "dev": true,
       "license": "ISC",
@@ -802,14 +802,14 @@
     },
     "node_modules/@angular/cli/node_modules/emoji-regex": {
       "version": "10.6.0",
-      "resolved": "https://npm.sinequa.com/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@angular/cli/node_modules/listr2": {
       "version": "9.0.1",
-      "resolved": "https://npm.sinequa.com/listr2/-/listr2-9.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.1.tgz",
       "integrity": "sha512-SL0JY3DaxylDuo/MecFeiC+7pedM0zia33zl0vcjgwcq1q1FWWF1To9EIauPbl8GbMCU0R2e0uJ8bZunhYKD2g==",
       "dev": true,
       "license": "MIT",
@@ -827,7 +827,7 @@
     },
     "node_modules/@angular/cli/node_modules/npm-package-arg": {
       "version": "13.0.0",
-      "resolved": "https://npm.sinequa.com/npm-package-arg/-/npm-package-arg-13.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-13.0.0.tgz",
       "integrity": "sha512-+t2etZAGcB7TbbLHfDwooV9ppB2LhhcT6A+L9cahsf9mEUAoQ6CktLEVvEnpD0N5CkX7zJqnPGaFtoQDy9EkHQ==",
       "dev": true,
       "license": "ISC",
@@ -843,7 +843,7 @@
     },
     "node_modules/@angular/cli/node_modules/semver": {
       "version": "7.7.2",
-      "resolved": "https://npm.sinequa.com/semver/-/semver-7.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
@@ -856,7 +856,7 @@
     },
     "node_modules/@angular/cli/node_modules/string-width": {
       "version": "7.2.0",
-      "resolved": "https://npm.sinequa.com/string-width/-/string-width-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "dev": true,
       "license": "MIT",
@@ -874,7 +874,7 @@
     },
     "node_modules/@angular/cli/node_modules/wrap-ansi": {
       "version": "9.0.2",
-      "resolved": "https://npm.sinequa.com/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
       "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
       "dev": true,
       "license": "MIT",
@@ -892,7 +892,7 @@
     },
     "node_modules/@angular/cli/node_modules/yargs": {
       "version": "18.0.0",
-      "resolved": "https://npm.sinequa.com/yargs/-/yargs-18.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
       "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
       "dev": true,
       "license": "MIT",
@@ -910,7 +910,7 @@
     },
     "node_modules/@angular/cli/node_modules/yargs-parser": {
       "version": "22.0.0",
-      "resolved": "https://npm.sinequa.com/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
       "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
       "dev": true,
       "license": "ISC",
@@ -920,7 +920,7 @@
     },
     "node_modules/@angular/cli/node_modules/zod": {
       "version": "4.1.13",
-      "resolved": "https://npm.sinequa.com/zod/-/zod-4.1.13.tgz",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.13.tgz",
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "dev": true,
       "license": "MIT",
@@ -930,7 +930,7 @@
     },
     "node_modules/@angular/common": {
       "version": "20.3.15",
-      "resolved": "https://npm.sinequa.com/@angular/common/-/common-20.3.15.tgz",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-20.3.15.tgz",
       "integrity": "sha512-k4mCXWRFiOHK3bUKfWkRQQ8KBPxW8TAJuKLYCsSHPCpMz6u0eA1F0VlrnOkZVKWPI792fOaEAWH2Y4PTaXlUHw==",
       "license": "MIT",
       "dependencies": {
@@ -946,7 +946,7 @@
     },
     "node_modules/@angular/compiler": {
       "version": "20.3.18",
-      "resolved": "https://npm.sinequa.com/@angular/compiler/-/compiler-20.3.18.tgz",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-20.3.18.tgz",
       "integrity": "sha512-AaP/LCiDNcYmF135EEozjyR04NRBT38ZfBHQwjhgwiBBTejmvcpHwJaHSkraLpZqZzE4BQqqmgiQ1EJqxEwLVA==",
       "license": "MIT",
       "dependencies": {
@@ -958,7 +958,7 @@
     },
     "node_modules/@angular/compiler-cli": {
       "version": "20.3.15",
-      "resolved": "https://npm.sinequa.com/@angular/compiler-cli/-/compiler-cli-20.3.15.tgz",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-20.3.15.tgz",
       "integrity": "sha512-8sJoxodxsfyZ8eJ5r6Bx7BCbazXYgsZ1+dE8t5u5rTQ6jNggwNtYEzkyReoD5xvP+MMtRkos3xpwq4rtFnpI6A==",
       "dev": true,
       "license": "MIT",
@@ -991,7 +991,7 @@
     },
     "node_modules/@angular/compiler-cli/node_modules/ansi-styles": {
       "version": "6.2.1",
-      "resolved": "https://npm.sinequa.com/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
       "dev": true,
       "license": "MIT",
@@ -1004,7 +1004,7 @@
     },
     "node_modules/@angular/compiler-cli/node_modules/cliui": {
       "version": "9.0.1",
-      "resolved": "https://npm.sinequa.com/cliui/-/cliui-9.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
       "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
       "dev": true,
       "license": "ISC",
@@ -1019,14 +1019,14 @@
     },
     "node_modules/@angular/compiler-cli/node_modules/emoji-regex": {
       "version": "10.4.0",
-      "resolved": "https://npm.sinequa.com/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
       "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@angular/compiler-cli/node_modules/string-width": {
       "version": "7.2.0",
-      "resolved": "https://npm.sinequa.com/string-width/-/string-width-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "dev": true,
       "license": "MIT",
@@ -1044,7 +1044,7 @@
     },
     "node_modules/@angular/compiler-cli/node_modules/wrap-ansi": {
       "version": "9.0.0",
-      "resolved": "https://npm.sinequa.com/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
       "integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
       "dev": true,
       "license": "MIT",
@@ -1062,7 +1062,7 @@
     },
     "node_modules/@angular/compiler-cli/node_modules/yargs": {
       "version": "18.0.0",
-      "resolved": "https://npm.sinequa.com/yargs/-/yargs-18.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
       "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
       "dev": true,
       "license": "MIT",
@@ -1080,7 +1080,7 @@
     },
     "node_modules/@angular/compiler-cli/node_modules/yargs-parser": {
       "version": "22.0.0",
-      "resolved": "https://npm.sinequa.com/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
       "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
       "dev": true,
       "license": "ISC",
@@ -1090,7 +1090,7 @@
     },
     "node_modules/@angular/core": {
       "version": "20.3.18",
-      "resolved": "https://npm.sinequa.com/@angular/core/-/core-20.3.18.tgz",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-20.3.18.tgz",
       "integrity": "sha512-B+NQQngd/aDbcfW0zGLis3wTLDeHTeTYMl/mGKQH+HwdPaRCKI1wEtaXaOYVJXkP2FeThocPevB8gLwNlPQUUw==",
       "license": "MIT",
       "dependencies": {
@@ -1115,7 +1115,7 @@
     },
     "node_modules/@angular/elements": {
       "version": "20.3.15",
-      "resolved": "https://npm.sinequa.com/@angular/elements/-/elements-20.3.15.tgz",
+      "resolved": "https://registry.npmjs.org/@angular/elements/-/elements-20.3.15.tgz",
       "integrity": "sha512-+wjqUBprhrssXOCVA8R1TzsBvGQr5tvh5zvVYK/TAmrd1st2j0dywXkhxJrtyblumELiFSQfbIn7CMrMNTBR6g==",
       "license": "MIT",
       "dependencies": {
@@ -1131,7 +1131,7 @@
     },
     "node_modules/@angular/forms": {
       "version": "20.3.15",
-      "resolved": "https://npm.sinequa.com/@angular/forms/-/forms-20.3.15.tgz",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-20.3.15.tgz",
       "integrity": "sha512-gS5hQkinq52pm/7mxz4yHPCzEcmRWjtUkOVddPH0V1BW/HMni/p4Y6k2KqKBeGb9p8S5EAp6PDxDVLOPukp3mg==",
       "license": "MIT",
       "dependencies": {
@@ -1149,7 +1149,7 @@
     },
     "node_modules/@angular/platform-browser": {
       "version": "20.3.15",
-      "resolved": "https://npm.sinequa.com/@angular/platform-browser/-/platform-browser-20.3.15.tgz",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-20.3.15.tgz",
       "integrity": "sha512-TxRM/wTW/oGXv/3/Iohn58yWoiYXOaeEnxSasiGNS1qhbkcKtR70xzxW6NjChBUYAixz2ERkLURkpx3pI8Q6Dw==",
       "license": "MIT",
       "dependencies": {
@@ -1171,7 +1171,7 @@
     },
     "node_modules/@angular/platform-browser-dynamic": {
       "version": "20.3.15",
-      "resolved": "https://npm.sinequa.com/@angular/platform-browser-dynamic/-/platform-browser-dynamic-20.3.15.tgz",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-20.3.15.tgz",
       "integrity": "sha512-RizuRdBt0d6ongQ2y8cr8YsXFyjF8f91vFfpSNw+cFj+oiEmRC1txcWUlH5bPLD9qSDied8qazUi0Tb8VPQDGw==",
       "license": "MIT",
       "dependencies": {
@@ -1189,7 +1189,7 @@
     },
     "node_modules/@angular/router": {
       "version": "20.3.15",
-      "resolved": "https://npm.sinequa.com/@angular/router/-/router-20.3.15.tgz",
+      "resolved": "https://registry.npmjs.org/@angular/router/-/router-20.3.15.tgz",
       "integrity": "sha512-6+qgk8swGSoAu7ISSY//GatAyCP36hEvvUgvjbZgkXLLH9yUQxdo77ij05aJ5s0OyB25q/JkqS8VTY0z1yE9NQ==",
       "license": "MIT",
       "dependencies": {
@@ -1207,7 +1207,7 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
-      "resolved": "https://npm.sinequa.com/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
       "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
       "license": "MIT",
       "dependencies": {
@@ -1221,7 +1221,7 @@
     },
     "node_modules/@babel/compat-data": {
       "version": "7.27.5",
-      "resolved": "https://npm.sinequa.com/@babel/compat-data/-/compat-data-7.27.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.27.5.tgz",
       "integrity": "sha512-KiRAp/VoJaWkkte84TvUd9qjdbZAdiqyvMxrGl1N6vzFogKmaLgoM3L1kgtLicp2HP5fBJS8JrZKLVIZGVJAVg==",
       "dev": true,
       "license": "MIT",
@@ -1231,7 +1231,7 @@
     },
     "node_modules/@babel/core": {
       "version": "7.28.3",
-      "resolved": "https://npm.sinequa.com/@babel/core/-/core-7.28.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.3.tgz",
       "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
       "dev": true,
       "license": "MIT",
@@ -1262,14 +1262,14 @@
     },
     "node_modules/@babel/core/node_modules/convert-source-map": {
       "version": "2.0.0",
-      "resolved": "https://npm.sinequa.com/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@babel/core/node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "https://npm.sinequa.com/semver/-/semver-6.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
@@ -1279,7 +1279,7 @@
     },
     "node_modules/@babel/generator": {
       "version": "7.28.5",
-      "resolved": "https://npm.sinequa.com/@babel/generator/-/generator-7.28.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
       "integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
       "dev": true,
       "license": "MIT",
@@ -1296,7 +1296,7 @@
     },
     "node_modules/@babel/helper-annotate-as-pure": {
       "version": "7.27.3",
-      "resolved": "https://npm.sinequa.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
       "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
       "dev": true,
       "license": "MIT",
@@ -1309,7 +1309,7 @@
     },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.27.2",
-      "resolved": "https://npm.sinequa.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
       "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
       "dev": true,
       "license": "MIT",
@@ -1326,7 +1326,7 @@
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "https://npm.sinequa.com/semver/-/semver-6.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
@@ -1336,7 +1336,7 @@
     },
     "node_modules/@babel/helper-globals": {
       "version": "7.28.0",
-      "resolved": "https://npm.sinequa.com/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
       "dev": true,
       "license": "MIT",
@@ -1346,7 +1346,7 @@
     },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.27.1",
-      "resolved": "https://npm.sinequa.com/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
       "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
       "dev": true,
       "license": "MIT",
@@ -1360,7 +1360,7 @@
     },
     "node_modules/@babel/helper-module-transforms": {
       "version": "7.28.3",
-      "resolved": "https://npm.sinequa.com/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
       "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
       "dev": true,
       "license": "MIT",
@@ -1378,7 +1378,7 @@
     },
     "node_modules/@babel/helper-split-export-declaration": {
       "version": "7.24.7",
-      "resolved": "https://npm.sinequa.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz",
       "integrity": "sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==",
       "dev": true,
       "license": "MIT",
@@ -1391,7 +1391,7 @@
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
-      "resolved": "https://npm.sinequa.com/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "dev": true,
       "license": "MIT",
@@ -1401,7 +1401,7 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.28.5",
-      "resolved": "https://npm.sinequa.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "license": "MIT",
       "engines": {
@@ -1410,7 +1410,7 @@
     },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.27.1",
-      "resolved": "https://npm.sinequa.com/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
       "dev": true,
       "license": "MIT",
@@ -1420,7 +1420,7 @@
     },
     "node_modules/@babel/helpers": {
       "version": "7.28.4",
-      "resolved": "https://npm.sinequa.com/@babel/helpers/-/helpers-7.28.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
       "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
       "dev": true,
       "license": "MIT",
@@ -1434,7 +1434,7 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.28.5",
-      "resolved": "https://npm.sinequa.com/@babel/parser/-/parser-7.28.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
       "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
       "dev": true,
       "license": "MIT",
@@ -1450,7 +1450,7 @@
     },
     "node_modules/@babel/runtime": {
       "version": "7.27.6",
-      "resolved": "https://npm.sinequa.com/@babel/runtime/-/runtime-7.27.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
       "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
       "license": "MIT",
       "engines": {
@@ -1459,7 +1459,7 @@
     },
     "node_modules/@babel/template": {
       "version": "7.27.2",
-      "resolved": "https://npm.sinequa.com/@babel/template/-/template-7.27.2.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
       "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
       "dev": true,
       "license": "MIT",
@@ -1474,7 +1474,7 @@
     },
     "node_modules/@babel/traverse": {
       "version": "7.28.5",
-      "resolved": "https://npm.sinequa.com/@babel/traverse/-/traverse-7.28.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
       "integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
       "dev": true,
       "license": "MIT",
@@ -1493,7 +1493,7 @@
     },
     "node_modules/@babel/types": {
       "version": "7.28.5",
-      "resolved": "https://npm.sinequa.com/@babel/types/-/types-7.28.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
       "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
       "dev": true,
       "license": "MIT",
@@ -1507,7 +1507,7 @@
     },
     "node_modules/@emnapi/core": {
       "version": "1.9.1",
-      "resolved": "https://npm.sinequa.com/@emnapi/core/-/core-1.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
       "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
       "dev": true,
       "license": "MIT",
@@ -1519,7 +1519,7 @@
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.9.1",
-      "resolved": "https://npm.sinequa.com/@emnapi/runtime/-/runtime-1.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
       "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
       "dev": true,
       "license": "MIT",
@@ -1530,7 +1530,7 @@
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.0",
-      "resolved": "https://npm.sinequa.com/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
       "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
       "dev": true,
       "license": "MIT",
@@ -1541,7 +1541,7 @@
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.9",
-      "resolved": "https://npm.sinequa.com/@esbuild/aix-ppc64/-/aix-ppc64-0.25.9.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.9.tgz",
       "integrity": "sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==",
       "cpu": [
         "ppc64"
@@ -1558,7 +1558,7 @@
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.25.9",
-      "resolved": "https://npm.sinequa.com/@esbuild/android-arm/-/android-arm-0.25.9.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.9.tgz",
       "integrity": "sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==",
       "cpu": [
         "arm"
@@ -1575,7 +1575,7 @@
     },
     "node_modules/@esbuild/android-arm64": {
       "version": "0.25.9",
-      "resolved": "https://npm.sinequa.com/@esbuild/android-arm64/-/android-arm64-0.25.9.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.9.tgz",
       "integrity": "sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==",
       "cpu": [
         "arm64"
@@ -1592,7 +1592,7 @@
     },
     "node_modules/@esbuild/android-x64": {
       "version": "0.25.9",
-      "resolved": "https://npm.sinequa.com/@esbuild/android-x64/-/android-x64-0.25.9.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.9.tgz",
       "integrity": "sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==",
       "cpu": [
         "x64"
@@ -1609,7 +1609,7 @@
     },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.25.9",
-      "resolved": "https://npm.sinequa.com/@esbuild/darwin-arm64/-/darwin-arm64-0.25.9.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.9.tgz",
       "integrity": "sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==",
       "cpu": [
         "arm64"
@@ -1626,7 +1626,7 @@
     },
     "node_modules/@esbuild/darwin-x64": {
       "version": "0.25.9",
-      "resolved": "https://npm.sinequa.com/@esbuild/darwin-x64/-/darwin-x64-0.25.9.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.9.tgz",
       "integrity": "sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==",
       "cpu": [
         "x64"
@@ -1643,7 +1643,7 @@
     },
     "node_modules/@esbuild/freebsd-arm64": {
       "version": "0.25.9",
-      "resolved": "https://npm.sinequa.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.9.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.9.tgz",
       "integrity": "sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==",
       "cpu": [
         "arm64"
@@ -1660,7 +1660,7 @@
     },
     "node_modules/@esbuild/freebsd-x64": {
       "version": "0.25.9",
-      "resolved": "https://npm.sinequa.com/@esbuild/freebsd-x64/-/freebsd-x64-0.25.9.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.9.tgz",
       "integrity": "sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==",
       "cpu": [
         "x64"
@@ -1677,7 +1677,7 @@
     },
     "node_modules/@esbuild/linux-arm": {
       "version": "0.25.9",
-      "resolved": "https://npm.sinequa.com/@esbuild/linux-arm/-/linux-arm-0.25.9.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.9.tgz",
       "integrity": "sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==",
       "cpu": [
         "arm"
@@ -1694,7 +1694,7 @@
     },
     "node_modules/@esbuild/linux-arm64": {
       "version": "0.25.9",
-      "resolved": "https://npm.sinequa.com/@esbuild/linux-arm64/-/linux-arm64-0.25.9.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.9.tgz",
       "integrity": "sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==",
       "cpu": [
         "arm64"
@@ -1711,7 +1711,7 @@
     },
     "node_modules/@esbuild/linux-ia32": {
       "version": "0.25.9",
-      "resolved": "https://npm.sinequa.com/@esbuild/linux-ia32/-/linux-ia32-0.25.9.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.9.tgz",
       "integrity": "sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==",
       "cpu": [
         "ia32"
@@ -1728,7 +1728,7 @@
     },
     "node_modules/@esbuild/linux-loong64": {
       "version": "0.25.9",
-      "resolved": "https://npm.sinequa.com/@esbuild/linux-loong64/-/linux-loong64-0.25.9.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.9.tgz",
       "integrity": "sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==",
       "cpu": [
         "loong64"
@@ -1745,7 +1745,7 @@
     },
     "node_modules/@esbuild/linux-mips64el": {
       "version": "0.25.9",
-      "resolved": "https://npm.sinequa.com/@esbuild/linux-mips64el/-/linux-mips64el-0.25.9.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.9.tgz",
       "integrity": "sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==",
       "cpu": [
         "mips64el"
@@ -1762,7 +1762,7 @@
     },
     "node_modules/@esbuild/linux-ppc64": {
       "version": "0.25.9",
-      "resolved": "https://npm.sinequa.com/@esbuild/linux-ppc64/-/linux-ppc64-0.25.9.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.9.tgz",
       "integrity": "sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==",
       "cpu": [
         "ppc64"
@@ -1779,7 +1779,7 @@
     },
     "node_modules/@esbuild/linux-riscv64": {
       "version": "0.25.9",
-      "resolved": "https://npm.sinequa.com/@esbuild/linux-riscv64/-/linux-riscv64-0.25.9.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.9.tgz",
       "integrity": "sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==",
       "cpu": [
         "riscv64"
@@ -1796,7 +1796,7 @@
     },
     "node_modules/@esbuild/linux-s390x": {
       "version": "0.25.9",
-      "resolved": "https://npm.sinequa.com/@esbuild/linux-s390x/-/linux-s390x-0.25.9.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.9.tgz",
       "integrity": "sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==",
       "cpu": [
         "s390x"
@@ -1813,7 +1813,7 @@
     },
     "node_modules/@esbuild/linux-x64": {
       "version": "0.25.9",
-      "resolved": "https://npm.sinequa.com/@esbuild/linux-x64/-/linux-x64-0.25.9.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.9.tgz",
       "integrity": "sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==",
       "cpu": [
         "x64"
@@ -1830,7 +1830,7 @@
     },
     "node_modules/@esbuild/netbsd-arm64": {
       "version": "0.25.9",
-      "resolved": "https://npm.sinequa.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.9.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.9.tgz",
       "integrity": "sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==",
       "cpu": [
         "arm64"
@@ -1847,7 +1847,7 @@
     },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.25.9",
-      "resolved": "https://npm.sinequa.com/@esbuild/netbsd-x64/-/netbsd-x64-0.25.9.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.9.tgz",
       "integrity": "sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==",
       "cpu": [
         "x64"
@@ -1864,7 +1864,7 @@
     },
     "node_modules/@esbuild/openbsd-arm64": {
       "version": "0.25.9",
-      "resolved": "https://npm.sinequa.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.9.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.9.tgz",
       "integrity": "sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==",
       "cpu": [
         "arm64"
@@ -1881,7 +1881,7 @@
     },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.25.9",
-      "resolved": "https://npm.sinequa.com/@esbuild/openbsd-x64/-/openbsd-x64-0.25.9.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.9.tgz",
       "integrity": "sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==",
       "cpu": [
         "x64"
@@ -1898,7 +1898,7 @@
     },
     "node_modules/@esbuild/openharmony-arm64": {
       "version": "0.25.9",
-      "resolved": "https://npm.sinequa.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.9.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.9.tgz",
       "integrity": "sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==",
       "cpu": [
         "arm64"
@@ -1915,7 +1915,7 @@
     },
     "node_modules/@esbuild/sunos-x64": {
       "version": "0.25.9",
-      "resolved": "https://npm.sinequa.com/@esbuild/sunos-x64/-/sunos-x64-0.25.9.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.9.tgz",
       "integrity": "sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==",
       "cpu": [
         "x64"
@@ -1932,7 +1932,7 @@
     },
     "node_modules/@esbuild/win32-arm64": {
       "version": "0.25.9",
-      "resolved": "https://npm.sinequa.com/@esbuild/win32-arm64/-/win32-arm64-0.25.9.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.9.tgz",
       "integrity": "sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==",
       "cpu": [
         "arm64"
@@ -1949,7 +1949,7 @@
     },
     "node_modules/@esbuild/win32-ia32": {
       "version": "0.25.9",
-      "resolved": "https://npm.sinequa.com/@esbuild/win32-ia32/-/win32-ia32-0.25.9.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.9.tgz",
       "integrity": "sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==",
       "cpu": [
         "ia32"
@@ -1966,7 +1966,7 @@
     },
     "node_modules/@esbuild/win32-x64": {
       "version": "0.25.9",
-      "resolved": "https://npm.sinequa.com/@esbuild/win32-x64/-/win32-x64-0.25.9.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.9.tgz",
       "integrity": "sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==",
       "cpu": [
         "x64"
@@ -1983,7 +1983,7 @@
     },
     "node_modules/@floating-ui/core": {
       "version": "1.7.3",
-      "resolved": "https://npm.sinequa.com/@floating-ui/core/-/core-1.7.3.tgz",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
       "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
       "license": "MIT",
       "dependencies": {
@@ -1992,7 +1992,7 @@
     },
     "node_modules/@floating-ui/dom": {
       "version": "1.7.4",
-      "resolved": "https://npm.sinequa.com/@floating-ui/dom/-/dom-1.7.4.tgz",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
       "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
       "license": "MIT",
       "dependencies": {
@@ -2002,19 +2002,19 @@
     },
     "node_modules/@floating-ui/utils": {
       "version": "0.2.10",
-      "resolved": "https://npm.sinequa.com/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
     },
     "node_modules/@flowjs/flow.js": {
       "version": "2.14.1",
-      "resolved": "https://npm.sinequa.com/@flowjs/flow.js/-/flow.js-2.14.1.tgz",
+      "resolved": "https://registry.npmjs.org/@flowjs/flow.js/-/flow.js-2.14.1.tgz",
       "integrity": "sha512-99DWlPnksOOS8uHfo+bhSjvs8d2MfLTB/22JBDC2ONwz/OCdP+gL/iiM4puMSTE2wH4A2/+J0eMc7pKwusXunw==",
       "license": "MIT"
     },
     "node_modules/@flowjs/ngx-flow": {
       "version": "0.6.0",
-      "resolved": "https://npm.sinequa.com/@flowjs/ngx-flow/-/ngx-flow-0.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/@flowjs/ngx-flow/-/ngx-flow-0.6.0.tgz",
       "integrity": "sha512-oWgOQSpfrzDuR6eG98/jkK523xxCb8OIWSbWM1/87KJZzUJBzuO0jQIZspVxURjQGTNOoFl8cl9P6iNXnvBgPg==",
       "license": "MIT",
       "dependencies": {
@@ -2028,7 +2028,7 @@
     },
     "node_modules/@hono/node-server": {
       "version": "1.19.14",
-      "resolved": "https://npm.sinequa.com/@hono/node-server/-/node-server-1.19.14.tgz",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
       "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "dev": true,
       "license": "MIT",
@@ -2041,7 +2041,7 @@
     },
     "node_modules/@inquirer/ansi": {
       "version": "1.0.2",
-      "resolved": "https://npm.sinequa.com/@inquirer/ansi/-/ansi-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
       "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
       "dev": true,
       "license": "MIT",
@@ -2051,7 +2051,7 @@
     },
     "node_modules/@inquirer/checkbox": {
       "version": "4.3.2",
-      "resolved": "https://npm.sinequa.com/@inquirer/checkbox/-/checkbox-4.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.2.tgz",
       "integrity": "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==",
       "dev": true,
       "license": "MIT",
@@ -2076,7 +2076,7 @@
     },
     "node_modules/@inquirer/confirm": {
       "version": "5.1.14",
-      "resolved": "https://npm.sinequa.com/@inquirer/confirm/-/confirm-5.1.14.tgz",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.14.tgz",
       "integrity": "sha512-5yR4IBfe0kXe59r1YCTG8WXkUbl7Z35HK87Sw+WUyGD8wNUx7JvY7laahzeytyE1oLn74bQnL7hstctQxisQ8Q==",
       "dev": true,
       "license": "MIT",
@@ -2098,7 +2098,7 @@
     },
     "node_modules/@inquirer/core": {
       "version": "10.3.2",
-      "resolved": "https://npm.sinequa.com/@inquirer/core/-/core-10.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
       "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
       "dev": true,
       "license": "MIT",
@@ -2126,7 +2126,7 @@
     },
     "node_modules/@inquirer/editor": {
       "version": "4.2.23",
-      "resolved": "https://npm.sinequa.com/@inquirer/editor/-/editor-4.2.23.tgz",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.23.tgz",
       "integrity": "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==",
       "dev": true,
       "license": "MIT",
@@ -2149,7 +2149,7 @@
     },
     "node_modules/@inquirer/expand": {
       "version": "4.0.23",
-      "resolved": "https://npm.sinequa.com/@inquirer/expand/-/expand-4.0.23.tgz",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.23.tgz",
       "integrity": "sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==",
       "dev": true,
       "license": "MIT",
@@ -2172,7 +2172,7 @@
     },
     "node_modules/@inquirer/external-editor": {
       "version": "1.0.3",
-      "resolved": "https://npm.sinequa.com/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
       "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
       "dev": true,
       "license": "MIT",
@@ -2194,7 +2194,7 @@
     },
     "node_modules/@inquirer/figures": {
       "version": "1.0.15",
-      "resolved": "https://npm.sinequa.com/@inquirer/figures/-/figures-1.0.15.tgz",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
       "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
       "dev": true,
       "license": "MIT",
@@ -2204,7 +2204,7 @@
     },
     "node_modules/@inquirer/input": {
       "version": "4.3.1",
-      "resolved": "https://npm.sinequa.com/@inquirer/input/-/input-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.3.1.tgz",
       "integrity": "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==",
       "dev": true,
       "license": "MIT",
@@ -2226,7 +2226,7 @@
     },
     "node_modules/@inquirer/number": {
       "version": "3.0.23",
-      "resolved": "https://npm.sinequa.com/@inquirer/number/-/number-3.0.23.tgz",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.23.tgz",
       "integrity": "sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==",
       "dev": true,
       "license": "MIT",
@@ -2248,7 +2248,7 @@
     },
     "node_modules/@inquirer/password": {
       "version": "4.0.23",
-      "resolved": "https://npm.sinequa.com/@inquirer/password/-/password-4.0.23.tgz",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.23.tgz",
       "integrity": "sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==",
       "dev": true,
       "license": "MIT",
@@ -2271,7 +2271,7 @@
     },
     "node_modules/@inquirer/prompts": {
       "version": "7.8.2",
-      "resolved": "https://npm.sinequa.com/@inquirer/prompts/-/prompts-7.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.8.2.tgz",
       "integrity": "sha512-nqhDw2ZcAUrKNPwhjinJny903bRhI0rQhiDz1LksjeRxqa36i3l75+4iXbOy0rlDpLJGxqtgoPavQjmmyS5UJw==",
       "dev": true,
       "license": "MIT",
@@ -2301,7 +2301,7 @@
     },
     "node_modules/@inquirer/rawlist": {
       "version": "4.1.11",
-      "resolved": "https://npm.sinequa.com/@inquirer/rawlist/-/rawlist-4.1.11.tgz",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.11.tgz",
       "integrity": "sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==",
       "dev": true,
       "license": "MIT",
@@ -2324,7 +2324,7 @@
     },
     "node_modules/@inquirer/search": {
       "version": "3.2.2",
-      "resolved": "https://npm.sinequa.com/@inquirer/search/-/search-3.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.2.tgz",
       "integrity": "sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==",
       "dev": true,
       "license": "MIT",
@@ -2348,7 +2348,7 @@
     },
     "node_modules/@inquirer/select": {
       "version": "4.4.2",
-      "resolved": "https://npm.sinequa.com/@inquirer/select/-/select-4.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.2.tgz",
       "integrity": "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==",
       "dev": true,
       "license": "MIT",
@@ -2373,7 +2373,7 @@
     },
     "node_modules/@inquirer/type": {
       "version": "3.0.10",
-      "resolved": "https://npm.sinequa.com/@inquirer/type/-/type-3.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
       "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
       "dev": true,
       "license": "MIT",
@@ -2391,7 +2391,7 @@
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
-      "resolved": "https://npm.sinequa.com/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
       "license": "ISC",
       "dependencies": {
@@ -2408,7 +2408,7 @@
     },
     "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
       "version": "6.2.1",
-      "resolved": "https://npm.sinequa.com/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
       "license": "MIT",
       "engines": {
@@ -2420,7 +2420,7 @@
     },
     "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
       "version": "8.1.0",
-      "resolved": "https://npm.sinequa.com/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
       "license": "MIT",
       "dependencies": {
@@ -2437,7 +2437,7 @@
     },
     "node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
-      "resolved": "https://npm.sinequa.com/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
       "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
       "license": "ISC",
       "dependencies": {
@@ -2449,7 +2449,7 @@
     },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
-      "resolved": "https://npm.sinequa.com/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true,
       "license": "MIT",
@@ -2459,7 +2459,7 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
-      "resolved": "https://npm.sinequa.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "license": "MIT",
       "dependencies": {
@@ -2469,7 +2469,7 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
-      "resolved": "https://npm.sinequa.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "license": "MIT",
       "engines": {
@@ -2478,13 +2478,13 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.0",
-      "resolved": "https://npm.sinequa.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
       "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
-      "resolved": "https://npm.sinequa.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "license": "MIT",
       "dependencies": {
@@ -2494,7 +2494,7 @@
     },
     "node_modules/@jsverse/transloco": {
       "version": "7.6.1",
-      "resolved": "https://npm.sinequa.com/@jsverse/transloco/-/transloco-7.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/@jsverse/transloco/-/transloco-7.6.1.tgz",
       "integrity": "sha512-hFFKJ1pVFYeW2E4UFETQpOeOn0tuncCSUdRewbq3LiV+qS9x4Z2XVuCaAaFPdiNhy4nUKHWFX1pWjpZ5XjUPaQ==",
       "license": "MIT",
       "dependencies": {
@@ -2512,7 +2512,7 @@
     },
     "node_modules/@jsverse/transloco-messageformat": {
       "version": "7.0.1",
-      "resolved": "https://npm.sinequa.com/@jsverse/transloco-messageformat/-/transloco-messageformat-7.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@jsverse/transloco-messageformat/-/transloco-messageformat-7.0.1.tgz",
       "integrity": "sha512-yhTizhEUD/omY40UWqQkQwRP9O7RxPkYB2QZlpgGu0IqS1RqNhmLX+j5MJLePZzpH3n9zfx+rkPM+oqfDsKBSg==",
       "license": "MIT",
       "dependencies": {
@@ -2527,7 +2527,7 @@
     },
     "node_modules/@jsverse/transloco-scoped-libs": {
       "version": "7.0.1",
-      "resolved": "https://npm.sinequa.com/@jsverse/transloco-scoped-libs/-/transloco-scoped-libs-7.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@jsverse/transloco-scoped-libs/-/transloco-scoped-libs-7.0.1.tgz",
       "integrity": "sha512-98PRvZp6CUzupV0bRd7cZAz3kRHMTknrIZDNN4g3V9OZZU/bSatD58Ej+eTgrdo2X1QTHkmy7KR41EqcH4WxDA==",
       "dev": true,
       "license": "MIT",
@@ -2548,7 +2548,7 @@
     },
     "node_modules/@jsverse/transloco-scoped-libs/node_modules/chokidar": {
       "version": "3.6.0",
-      "resolved": "https://npm.sinequa.com/chokidar/-/chokidar-3.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
       "dev": true,
       "license": "MIT",
@@ -2573,7 +2573,7 @@
     },
     "node_modules/@jsverse/transloco-scoped-libs/node_modules/picomatch": {
       "version": "2.3.2",
-      "resolved": "https://npm.sinequa.com/picomatch/-/picomatch-2.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
@@ -2586,7 +2586,7 @@
     },
     "node_modules/@jsverse/transloco-scoped-libs/node_modules/readdirp": {
       "version": "3.6.0",
-      "resolved": "https://npm.sinequa.com/readdirp/-/readdirp-3.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dev": true,
       "license": "MIT",
@@ -2599,7 +2599,7 @@
     },
     "node_modules/@jsverse/transloco-utils": {
       "version": "7.0.2",
-      "resolved": "https://npm.sinequa.com/@jsverse/transloco-utils/-/transloco-utils-7.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@jsverse/transloco-utils/-/transloco-utils-7.0.2.tgz",
       "integrity": "sha512-zud1M68mMC/Pu6irEba+Z2SzmwmmPzUPnBzMKlcGdIhzUe1z41cqQutK1M0QaQpY4h4yhumXcNaY/Ot6piv6QQ==",
       "license": "MIT",
       "dependencies": {
@@ -2612,13 +2612,13 @@
     },
     "node_modules/@kurkle/color": {
       "version": "0.3.4",
-      "resolved": "https://npm.sinequa.com/@kurkle/color/-/color-0.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
       "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
       "license": "MIT"
     },
     "node_modules/@listr2/prompt-adapter-inquirer": {
       "version": "3.0.1",
-      "resolved": "https://npm.sinequa.com/@listr2/prompt-adapter-inquirer/-/prompt-adapter-inquirer-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@listr2/prompt-adapter-inquirer/-/prompt-adapter-inquirer-3.0.1.tgz",
       "integrity": "sha512-3XFmGwm3u6ioREG+ynAQB7FoxfajgQnMhIu8wC5eo/Lsih4aKDg0VuIMGaOsYn7hJSJagSeaD4K8yfpkEoDEmA==",
       "dev": true,
       "license": "MIT",
@@ -2635,7 +2635,7 @@
     },
     "node_modules/@lmdb/lmdb-darwin-arm64": {
       "version": "3.4.2",
-      "resolved": "https://npm.sinequa.com/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-3.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-3.4.2.tgz",
       "integrity": "sha512-NK80WwDoODyPaSazKbzd3NEJ3ygePrkERilZshxBViBARNz21rmediktGHExoj9n5t9+ChlgLlxecdFKLCuCKg==",
       "cpu": [
         "arm64"
@@ -2649,7 +2649,7 @@
     },
     "node_modules/@lmdb/lmdb-darwin-x64": {
       "version": "3.4.2",
-      "resolved": "https://npm.sinequa.com/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-3.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-3.4.2.tgz",
       "integrity": "sha512-zevaowQNmrp3U7Fz1s9pls5aIgpKRsKb3dZWDINtLiozh3jZI9fBrI19lYYBxqdyiIyNdlyiidPnwPShj4aK+w==",
       "cpu": [
         "x64"
@@ -2663,7 +2663,7 @@
     },
     "node_modules/@lmdb/lmdb-linux-arm": {
       "version": "3.4.2",
-      "resolved": "https://npm.sinequa.com/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-3.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-3.4.2.tgz",
       "integrity": "sha512-OmHCULY17rkx/RoCoXlzU7LyR8xqrksgdYWwtYa14l/sseezZ8seKWXcogHcjulBddER5NnEFV4L/Jtr2nyxeg==",
       "cpu": [
         "arm"
@@ -2677,7 +2677,7 @@
     },
     "node_modules/@lmdb/lmdb-linux-arm64": {
       "version": "3.4.2",
-      "resolved": "https://npm.sinequa.com/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-3.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-3.4.2.tgz",
       "integrity": "sha512-ZBEfbNZdkneebvZs98Lq30jMY8V9IJzckVeigGivV7nTHJc+89Ctomp1kAIWKlwIG0ovCDrFI448GzFPORANYg==",
       "cpu": [
         "arm64"
@@ -2691,7 +2691,7 @@
     },
     "node_modules/@lmdb/lmdb-linux-x64": {
       "version": "3.4.2",
-      "resolved": "https://npm.sinequa.com/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-3.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-3.4.2.tgz",
       "integrity": "sha512-vL9nM17C77lohPYE4YaAQvfZCSVJSryE4fXdi8M7uWPBnU+9DJabgKVAeyDb84ZM2vcFseoBE4/AagVtJeRE7g==",
       "cpu": [
         "x64"
@@ -2705,7 +2705,7 @@
     },
     "node_modules/@lmdb/lmdb-win32-arm64": {
       "version": "3.4.2",
-      "resolved": "https://npm.sinequa.com/@lmdb/lmdb-win32-arm64/-/lmdb-win32-arm64-3.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-arm64/-/lmdb-win32-arm64-3.4.2.tgz",
       "integrity": "sha512-SXWjdBfNDze4ZPeLtYIzsIeDJDJ/SdsA0pEXcUBayUIMO0FQBHfVZZyHXQjjHr4cvOAzANBgIiqaXRwfMhzmLw==",
       "cpu": [
         "arm64"
@@ -2719,7 +2719,7 @@
     },
     "node_modules/@lmdb/lmdb-win32-x64": {
       "version": "3.4.2",
-      "resolved": "https://npm.sinequa.com/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-3.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-3.4.2.tgz",
       "integrity": "sha512-IY+r3bxKW6Q6sIPiMC0L533DEfRJSXibjSI3Ft/w9Q8KQBNqEIvUFXt+09wV8S5BRk0a8uSF19YWxuRwEfI90g==",
       "cpu": [
         "x64"
@@ -2733,7 +2733,7 @@
     },
     "node_modules/@messageformat/core": {
       "version": "3.4.0",
-      "resolved": "https://npm.sinequa.com/@messageformat/core/-/core-3.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/@messageformat/core/-/core-3.4.0.tgz",
       "integrity": "sha512-NgCFubFFIdMWJGN5WuQhHCNmzk7QgiVfrViFxcS99j7F5dDS5EP6raR54I+2ydhe4+5/XTn/YIEppFaqqVWHsw==",
       "license": "MIT",
       "dependencies": {
@@ -2747,19 +2747,19 @@
     },
     "node_modules/@messageformat/date-skeleton": {
       "version": "1.1.0",
-      "resolved": "https://npm.sinequa.com/@messageformat/date-skeleton/-/date-skeleton-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@messageformat/date-skeleton/-/date-skeleton-1.1.0.tgz",
       "integrity": "sha512-rmGAfB1tIPER+gh3p/RgA+PVeRE/gxuQ2w4snFWPF5xtb5mbWR7Cbw7wCOftcUypbD6HVoxrVdyyghPm3WzP5A==",
       "license": "MIT"
     },
     "node_modules/@messageformat/number-skeleton": {
       "version": "1.2.0",
-      "resolved": "https://npm.sinequa.com/@messageformat/number-skeleton/-/number-skeleton-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@messageformat/number-skeleton/-/number-skeleton-1.2.0.tgz",
       "integrity": "sha512-xsgwcL7J7WhlHJ3RNbaVgssaIwcEyFkBqxHdcdaiJzwTZAWEOD8BuUFxnxV9k5S0qHN3v/KzUpq0IUpjH1seRg==",
       "license": "MIT"
     },
     "node_modules/@messageformat/parser": {
       "version": "5.1.1",
-      "resolved": "https://npm.sinequa.com/@messageformat/parser/-/parser-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@messageformat/parser/-/parser-5.1.1.tgz",
       "integrity": "sha512-3p0YRGCcTUCYvBKLIxtDDyrJ0YijGIwrTRu1DT8gIviIDZru8H23+FkY6MJBzM1n9n20CiM4VeDYuBsrrwnLjg==",
       "license": "MIT",
       "dependencies": {
@@ -2768,7 +2768,7 @@
     },
     "node_modules/@messageformat/runtime": {
       "version": "3.0.2",
-      "resolved": "https://npm.sinequa.com/@messageformat/runtime/-/runtime-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@messageformat/runtime/-/runtime-3.0.2.tgz",
       "integrity": "sha512-dkIPDCjXcfhSHgNE1/qV6TeczQZR59Yx0xXeafVKgK3QVWoxc38ljwpksUpnzCGvN151KUbCJTDZVmahtf1YZw==",
       "license": "MIT",
       "dependencies": {
@@ -2777,7 +2777,7 @@
     },
     "node_modules/@microsoft/signalr": {
       "version": "7.0.14",
-      "resolved": "https://npm.sinequa.com/@microsoft/signalr/-/signalr-7.0.14.tgz",
+      "resolved": "https://registry.npmjs.org/@microsoft/signalr/-/signalr-7.0.14.tgz",
       "integrity": "sha512-dnS7gSJF5LxByZwJaj82+F1K755ya7ttPT+JnSeCBef3sL8p8FBkHePXphK8NSuOquIb7vsphXWa28A+L2SPpw==",
       "license": "MIT",
       "dependencies": {
@@ -2790,7 +2790,7 @@
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.26.0",
-      "resolved": "https://npm.sinequa.com/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
       "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
       "dev": true,
       "license": "MIT",
@@ -2831,7 +2831,7 @@
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/eventsource": {
       "version": "3.0.7",
-      "resolved": "https://npm.sinequa.com/eventsource/-/eventsource-3.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
       "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
       "dev": true,
       "license": "MIT",
@@ -2844,7 +2844,7 @@
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
       "version": "3.0.3",
-      "resolved": "https://npm.sinequa.com/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
       "integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
       "cpu": [
         "arm64"
@@ -2858,7 +2858,7 @@
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
       "version": "3.0.3",
-      "resolved": "https://npm.sinequa.com/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
       "integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
       "cpu": [
         "x64"
@@ -2872,7 +2872,7 @@
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
       "version": "3.0.3",
-      "resolved": "https://npm.sinequa.com/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
       "integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
       "cpu": [
         "arm"
@@ -2886,7 +2886,7 @@
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
       "version": "3.0.3",
-      "resolved": "https://npm.sinequa.com/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
       "integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
       "cpu": [
         "arm64"
@@ -2900,7 +2900,7 @@
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
       "version": "3.0.3",
-      "resolved": "https://npm.sinequa.com/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
       "integrity": "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==",
       "cpu": [
         "x64"
@@ -2914,7 +2914,7 @@
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
       "version": "3.0.3",
-      "resolved": "https://npm.sinequa.com/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
       "integrity": "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==",
       "cpu": [
         "x64"
@@ -2928,7 +2928,7 @@
     },
     "node_modules/@napi-rs/nice": {
       "version": "1.1.1",
-      "resolved": "https://npm.sinequa.com/@napi-rs/nice/-/nice-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice/-/nice-1.1.1.tgz",
       "integrity": "sha512-xJIPs+bYuc9ASBl+cvGsKbGrJmS6fAKaSZCnT0lhahT5rhA2VVy9/EcIgd2JhtEuFOJNx7UHNn/qiTPTY4nrQw==",
       "dev": true,
       "license": "MIT",
@@ -2962,7 +2962,7 @@
     },
     "node_modules/@napi-rs/nice-android-arm-eabi": {
       "version": "1.1.1",
-      "resolved": "https://npm.sinequa.com/@napi-rs/nice-android-arm-eabi/-/nice-android-arm-eabi-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-android-arm-eabi/-/nice-android-arm-eabi-1.1.1.tgz",
       "integrity": "sha512-kjirL3N6TnRPv5iuHw36wnucNqXAO46dzK9oPb0wj076R5Xm8PfUVA9nAFB5ZNMmfJQJVKACAPd/Z2KYMppthw==",
       "cpu": [
         "arm"
@@ -2979,7 +2979,7 @@
     },
     "node_modules/@napi-rs/nice-android-arm64": {
       "version": "1.1.1",
-      "resolved": "https://npm.sinequa.com/@napi-rs/nice-android-arm64/-/nice-android-arm64-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-android-arm64/-/nice-android-arm64-1.1.1.tgz",
       "integrity": "sha512-blG0i7dXgbInN5urONoUCNf+DUEAavRffrO7fZSeoRMJc5qD+BJeNcpr54msPF6qfDD6kzs9AQJogZvT2KD5nw==",
       "cpu": [
         "arm64"
@@ -2996,7 +2996,7 @@
     },
     "node_modules/@napi-rs/nice-darwin-arm64": {
       "version": "1.1.1",
-      "resolved": "https://npm.sinequa.com/@napi-rs/nice-darwin-arm64/-/nice-darwin-arm64-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-darwin-arm64/-/nice-darwin-arm64-1.1.1.tgz",
       "integrity": "sha512-s/E7w45NaLqTGuOjC2p96pct4jRfo61xb9bU1unM/MJ/RFkKlJyJDx7OJI/O0ll/hrfpqKopuAFDV8yo0hfT7A==",
       "cpu": [
         "arm64"
@@ -3013,7 +3013,7 @@
     },
     "node_modules/@napi-rs/nice-darwin-x64": {
       "version": "1.1.1",
-      "resolved": "https://npm.sinequa.com/@napi-rs/nice-darwin-x64/-/nice-darwin-x64-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-darwin-x64/-/nice-darwin-x64-1.1.1.tgz",
       "integrity": "sha512-dGoEBnVpsdcC+oHHmW1LRK5eiyzLwdgNQq3BmZIav+9/5WTZwBYX7r5ZkQC07Nxd3KHOCkgbHSh4wPkH1N1LiQ==",
       "cpu": [
         "x64"
@@ -3030,7 +3030,7 @@
     },
     "node_modules/@napi-rs/nice-freebsd-x64": {
       "version": "1.1.1",
-      "resolved": "https://npm.sinequa.com/@napi-rs/nice-freebsd-x64/-/nice-freebsd-x64-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-freebsd-x64/-/nice-freebsd-x64-1.1.1.tgz",
       "integrity": "sha512-kHv4kEHAylMYmlNwcQcDtXjklYp4FCf0b05E+0h6nDHsZ+F0bDe04U/tXNOqrx5CmIAth4vwfkjjUmp4c4JktQ==",
       "cpu": [
         "x64"
@@ -3047,7 +3047,7 @@
     },
     "node_modules/@napi-rs/nice-linux-arm-gnueabihf": {
       "version": "1.1.1",
-      "resolved": "https://npm.sinequa.com/@napi-rs/nice-linux-arm-gnueabihf/-/nice-linux-arm-gnueabihf-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-arm-gnueabihf/-/nice-linux-arm-gnueabihf-1.1.1.tgz",
       "integrity": "sha512-E1t7K0efyKXZDoZg1LzCOLxgolxV58HCkaEkEvIYQx12ht2pa8hoBo+4OB3qh7e+QiBlp1SRf+voWUZFxyhyqg==",
       "cpu": [
         "arm"
@@ -3064,7 +3064,7 @@
     },
     "node_modules/@napi-rs/nice-linux-arm64-gnu": {
       "version": "1.1.1",
-      "resolved": "https://npm.sinequa.com/@napi-rs/nice-linux-arm64-gnu/-/nice-linux-arm64-gnu-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-arm64-gnu/-/nice-linux-arm64-gnu-1.1.1.tgz",
       "integrity": "sha512-CIKLA12DTIZlmTaaKhQP88R3Xao+gyJxNWEn04wZwC2wmRapNnxCUZkVwggInMJvtVElA+D4ZzOU5sX4jV+SmQ==",
       "cpu": [
         "arm64"
@@ -3081,7 +3081,7 @@
     },
     "node_modules/@napi-rs/nice-linux-arm64-musl": {
       "version": "1.1.1",
-      "resolved": "https://npm.sinequa.com/@napi-rs/nice-linux-arm64-musl/-/nice-linux-arm64-musl-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-arm64-musl/-/nice-linux-arm64-musl-1.1.1.tgz",
       "integrity": "sha512-+2Rzdb3nTIYZ0YJF43qf2twhqOCkiSrHx2Pg6DJaCPYhhaxbLcdlV8hCRMHghQ+EtZQWGNcS2xF4KxBhSGeutg==",
       "cpu": [
         "arm64"
@@ -3098,7 +3098,7 @@
     },
     "node_modules/@napi-rs/nice-linux-ppc64-gnu": {
       "version": "1.1.1",
-      "resolved": "https://npm.sinequa.com/@napi-rs/nice-linux-ppc64-gnu/-/nice-linux-ppc64-gnu-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-ppc64-gnu/-/nice-linux-ppc64-gnu-1.1.1.tgz",
       "integrity": "sha512-4FS8oc0GeHpwvv4tKciKkw3Y4jKsL7FRhaOeiPei0X9T4Jd619wHNe4xCLmN2EMgZoeGg+Q7GY7BsvwKpL22Tg==",
       "cpu": [
         "ppc64"
@@ -3115,7 +3115,7 @@
     },
     "node_modules/@napi-rs/nice-linux-riscv64-gnu": {
       "version": "1.1.1",
-      "resolved": "https://npm.sinequa.com/@napi-rs/nice-linux-riscv64-gnu/-/nice-linux-riscv64-gnu-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-riscv64-gnu/-/nice-linux-riscv64-gnu-1.1.1.tgz",
       "integrity": "sha512-HU0nw9uD4FO/oGCCk409tCi5IzIZpH2agE6nN4fqpwVlCn5BOq0MS1dXGjXaG17JaAvrlpV5ZeyZwSon10XOXw==",
       "cpu": [
         "riscv64"
@@ -3132,7 +3132,7 @@
     },
     "node_modules/@napi-rs/nice-linux-s390x-gnu": {
       "version": "1.1.1",
-      "resolved": "https://npm.sinequa.com/@napi-rs/nice-linux-s390x-gnu/-/nice-linux-s390x-gnu-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-s390x-gnu/-/nice-linux-s390x-gnu-1.1.1.tgz",
       "integrity": "sha512-2YqKJWWl24EwrX0DzCQgPLKQBxYDdBxOHot1KWEq7aY2uYeX+Uvtv4I8xFVVygJDgf6/92h9N3Y43WPx8+PAgQ==",
       "cpu": [
         "s390x"
@@ -3149,7 +3149,7 @@
     },
     "node_modules/@napi-rs/nice-linux-x64-gnu": {
       "version": "1.1.1",
-      "resolved": "https://npm.sinequa.com/@napi-rs/nice-linux-x64-gnu/-/nice-linux-x64-gnu-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-x64-gnu/-/nice-linux-x64-gnu-1.1.1.tgz",
       "integrity": "sha512-/gaNz3R92t+dcrfCw/96pDopcmec7oCcAQ3l/M+Zxr82KT4DljD37CpgrnXV+pJC263JkW572pdbP3hP+KjcIg==",
       "cpu": [
         "x64"
@@ -3166,7 +3166,7 @@
     },
     "node_modules/@napi-rs/nice-linux-x64-musl": {
       "version": "1.1.1",
-      "resolved": "https://npm.sinequa.com/@napi-rs/nice-linux-x64-musl/-/nice-linux-x64-musl-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-x64-musl/-/nice-linux-x64-musl-1.1.1.tgz",
       "integrity": "sha512-xScCGnyj/oppsNPMnevsBe3pvNaoK7FGvMjT35riz9YdhB2WtTG47ZlbxtOLpjeO9SqqQ2J2igCmz6IJOD5JYw==",
       "cpu": [
         "x64"
@@ -3183,7 +3183,7 @@
     },
     "node_modules/@napi-rs/nice-openharmony-arm64": {
       "version": "1.1.1",
-      "resolved": "https://npm.sinequa.com/@napi-rs/nice-openharmony-arm64/-/nice-openharmony-arm64-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-openharmony-arm64/-/nice-openharmony-arm64-1.1.1.tgz",
       "integrity": "sha512-6uJPRVwVCLDeoOaNyeiW0gp2kFIM4r7PL2MczdZQHkFi9gVlgm+Vn+V6nTWRcu856mJ2WjYJiumEajfSm7arPQ==",
       "cpu": [
         "arm64"
@@ -3200,7 +3200,7 @@
     },
     "node_modules/@napi-rs/nice-win32-arm64-msvc": {
       "version": "1.1.1",
-      "resolved": "https://npm.sinequa.com/@napi-rs/nice-win32-arm64-msvc/-/nice-win32-arm64-msvc-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-win32-arm64-msvc/-/nice-win32-arm64-msvc-1.1.1.tgz",
       "integrity": "sha512-uoTb4eAvM5B2aj/z8j+Nv8OttPf2m+HVx3UjA5jcFxASvNhQriyCQF1OB1lHL43ZhW+VwZlgvjmP5qF3+59atA==",
       "cpu": [
         "arm64"
@@ -3217,7 +3217,7 @@
     },
     "node_modules/@napi-rs/nice-win32-ia32-msvc": {
       "version": "1.1.1",
-      "resolved": "https://npm.sinequa.com/@napi-rs/nice-win32-ia32-msvc/-/nice-win32-ia32-msvc-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-win32-ia32-msvc/-/nice-win32-ia32-msvc-1.1.1.tgz",
       "integrity": "sha512-CNQqlQT9MwuCsg1Vd/oKXiuH+TcsSPJmlAFc5frFyX/KkOh0UpBLEj7aoY656d5UKZQMQFP7vJNa1DNUNORvug==",
       "cpu": [
         "ia32"
@@ -3234,7 +3234,7 @@
     },
     "node_modules/@napi-rs/nice-win32-x64-msvc": {
       "version": "1.1.1",
-      "resolved": "https://npm.sinequa.com/@napi-rs/nice-win32-x64-msvc/-/nice-win32-x64-msvc-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-win32-x64-msvc/-/nice-win32-x64-msvc-1.1.1.tgz",
       "integrity": "sha512-vB+4G/jBQCAh0jelMTY3+kgFy00Hlx2f2/1zjMoH821IbplbWZOkLiTYXQkygNTzQJTq5cvwBDgn2ppHD+bglQ==",
       "cpu": [
         "x64"
@@ -3251,7 +3251,7 @@
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.2",
-      "resolved": "https://npm.sinequa.com/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
       "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
       "dev": true,
       "license": "MIT",
@@ -3270,7 +3270,7 @@
     },
     "node_modules/@ngrx/signals": {
       "version": "20.1.0",
-      "resolved": "https://npm.sinequa.com/@ngrx/signals/-/signals-20.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@ngrx/signals/-/signals-20.1.0.tgz",
       "integrity": "sha512-ARAHp5yA131Sw6FEtY8XtYcdGcwW5lgpZaJoDIRxc6i12VO3ZDZYp3M/FQhpIDMDXkXHR+pDqoitrqvzI69aQA==",
       "license": "MIT",
       "dependencies": {
@@ -3288,7 +3288,7 @@
     },
     "node_modules/@ngrx/store": {
       "version": "20.1.0",
-      "resolved": "https://npm.sinequa.com/@ngrx/store/-/store-20.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@ngrx/store/-/store-20.1.0.tgz",
       "integrity": "sha512-o8j3CGAGedm+BIb+QDhNXrVaU//n9uF0wH0HZWtXHmW1mjRBaQiUA+ZPMUkDwAeN8KuOcoIEC+2QUXxXGVI7ow==",
       "license": "MIT",
       "dependencies": {
@@ -3301,7 +3301,7 @@
     },
     "node_modules/@npmcli/agent": {
       "version": "4.0.0",
-      "resolved": "https://npm.sinequa.com/@npmcli/agent/-/agent-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.0.tgz",
       "integrity": "sha512-kAQTcEN9E8ERLVg5AsGwLNoFb+oEG6engbqAU2P43gD4JEIkNGMHdVQ096FsOAAYpZPB0RSt0zgInKIAS1l5QA==",
       "dev": true,
       "license": "ISC",
@@ -3318,7 +3318,7 @@
     },
     "node_modules/@npmcli/agent/node_modules/lru-cache": {
       "version": "11.2.5",
-      "resolved": "https://npm.sinequa.com/lru-cache/-/lru-cache-11.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
       "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -3328,7 +3328,7 @@
     },
     "node_modules/@npmcli/fs": {
       "version": "5.0.0",
-      "resolved": "https://npm.sinequa.com/@npmcli/fs/-/fs-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-5.0.0.tgz",
       "integrity": "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==",
       "dev": true,
       "license": "ISC",
@@ -3341,7 +3341,7 @@
     },
     "node_modules/@npmcli/git": {
       "version": "7.0.1",
-      "resolved": "https://npm.sinequa.com/@npmcli/git/-/git-7.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-7.0.1.tgz",
       "integrity": "sha512-+XTFxK2jJF/EJJ5SoAzXk3qwIDfvFc5/g+bD274LZ7uY7LE8sTfG6Z8rOanPl2ZEvZWqNvmEdtXC25cE54VcoA==",
       "dev": true,
       "license": "ISC",
@@ -3361,7 +3361,7 @@
     },
     "node_modules/@npmcli/git/node_modules/ini": {
       "version": "6.0.0",
-      "resolved": "https://npm.sinequa.com/ini/-/ini-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
       "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
       "dev": true,
       "license": "ISC",
@@ -3371,7 +3371,7 @@
     },
     "node_modules/@npmcli/git/node_modules/isexe": {
       "version": "3.1.1",
-      "resolved": "https://npm.sinequa.com/isexe/-/isexe-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
       "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
       "dev": true,
       "license": "ISC",
@@ -3381,7 +3381,7 @@
     },
     "node_modules/@npmcli/git/node_modules/lru-cache": {
       "version": "11.2.5",
-      "resolved": "https://npm.sinequa.com/lru-cache/-/lru-cache-11.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
       "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -3391,7 +3391,7 @@
     },
     "node_modules/@npmcli/git/node_modules/proc-log": {
       "version": "6.1.0",
-      "resolved": "https://npm.sinequa.com/proc-log/-/proc-log-6.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
       "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
       "dev": true,
       "license": "ISC",
@@ -3401,7 +3401,7 @@
     },
     "node_modules/@npmcli/git/node_modules/which": {
       "version": "6.0.0",
-      "resolved": "https://npm.sinequa.com/which/-/which-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.0.tgz",
       "integrity": "sha512-f+gEpIKMR9faW/JgAgPK1D7mekkFoqbmiwvNzuhsHetni20QSgzg9Vhn0g2JSJkkfehQnqdUAx7/e15qS1lPxg==",
       "dev": true,
       "license": "ISC",
@@ -3417,7 +3417,7 @@
     },
     "node_modules/@npmcli/installed-package-contents": {
       "version": "4.0.0",
-      "resolved": "https://npm.sinequa.com/@npmcli/installed-package-contents/-/installed-package-contents-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-4.0.0.tgz",
       "integrity": "sha512-yNyAdkBxB72gtZ4GrwXCM0ZUedo9nIbOMKfGjt6Cu6DXf0p8y1PViZAKDC8q8kv/fufx0WTjRBdSlyrvnP7hmA==",
       "dev": true,
       "license": "ISC",
@@ -3434,7 +3434,7 @@
     },
     "node_modules/@npmcli/node-gyp": {
       "version": "5.0.0",
-      "resolved": "https://npm.sinequa.com/@npmcli/node-gyp/-/node-gyp-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-5.0.0.tgz",
       "integrity": "sha512-uuG5HZFXLfyFKqg8QypsmgLQW7smiRjVc45bqD/ofZZcR/uxEjgQU8qDPv0s9TEeMUiAAU/GC5bR6++UdTirIQ==",
       "dev": true,
       "license": "ISC",
@@ -3444,7 +3444,7 @@
     },
     "node_modules/@npmcli/package-json": {
       "version": "7.0.4",
-      "resolved": "https://npm.sinequa.com/@npmcli/package-json/-/package-json-7.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-7.0.4.tgz",
       "integrity": "sha512-0wInJG3j/K40OJt/33ax47WfWMzZTm6OQxB9cDhTt5huCP2a9g2GnlsxmfN+PulItNPIpPrZ+kfwwUil7eHcZQ==",
       "dev": true,
       "license": "ISC",
@@ -3463,7 +3463,7 @@
     },
     "node_modules/@npmcli/package-json/node_modules/balanced-match": {
       "version": "4.0.4",
-      "resolved": "https://npm.sinequa.com/balanced-match/-/balanced-match-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
       "license": "MIT",
@@ -3473,7 +3473,7 @@
     },
     "node_modules/@npmcli/package-json/node_modules/brace-expansion": {
       "version": "5.0.5",
-      "resolved": "https://npm.sinequa.com/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
       "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
@@ -3486,7 +3486,7 @@
     },
     "node_modules/@npmcli/package-json/node_modules/glob": {
       "version": "13.0.1",
-      "resolved": "https://npm.sinequa.com/glob/-/glob-13.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.1.tgz",
       "integrity": "sha512-B7U/vJpE3DkJ5WXTgTpTRN63uV42DseiXXKMwG14LQBXmsdeIoHAPbU/MEo6II0k5ED74uc2ZGTC6MwHFQhF6w==",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -3504,7 +3504,7 @@
     },
     "node_modules/@npmcli/package-json/node_modules/lru-cache": {
       "version": "11.2.5",
-      "resolved": "https://npm.sinequa.com/lru-cache/-/lru-cache-11.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
       "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -3514,7 +3514,7 @@
     },
     "node_modules/@npmcli/package-json/node_modules/minimatch": {
       "version": "10.2.4",
-      "resolved": "https://npm.sinequa.com/minimatch/-/minimatch-10.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
       "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -3530,7 +3530,7 @@
     },
     "node_modules/@npmcli/package-json/node_modules/path-scurry": {
       "version": "2.0.1",
-      "resolved": "https://npm.sinequa.com/path-scurry/-/path-scurry-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
       "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -3547,7 +3547,7 @@
     },
     "node_modules/@npmcli/package-json/node_modules/proc-log": {
       "version": "6.1.0",
-      "resolved": "https://npm.sinequa.com/proc-log/-/proc-log-6.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
       "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
       "dev": true,
       "license": "ISC",
@@ -3557,7 +3557,7 @@
     },
     "node_modules/@npmcli/promise-spawn": {
       "version": "9.0.1",
-      "resolved": "https://npm.sinequa.com/@npmcli/promise-spawn/-/promise-spawn-9.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-9.0.1.tgz",
       "integrity": "sha512-OLUaoqBuyxeTqUvjA3FZFiXUfYC1alp3Sa99gW3EUDz3tZ3CbXDdcZ7qWKBzicrJleIgucoWamWH1saAmH/l2Q==",
       "dev": true,
       "license": "ISC",
@@ -3570,7 +3570,7 @@
     },
     "node_modules/@npmcli/promise-spawn/node_modules/isexe": {
       "version": "3.1.1",
-      "resolved": "https://npm.sinequa.com/isexe/-/isexe-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
       "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
       "dev": true,
       "license": "ISC",
@@ -3580,7 +3580,7 @@
     },
     "node_modules/@npmcli/promise-spawn/node_modules/which": {
       "version": "6.0.0",
-      "resolved": "https://npm.sinequa.com/which/-/which-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.0.tgz",
       "integrity": "sha512-f+gEpIKMR9faW/JgAgPK1D7mekkFoqbmiwvNzuhsHetni20QSgzg9Vhn0g2JSJkkfehQnqdUAx7/e15qS1lPxg==",
       "dev": true,
       "license": "ISC",
@@ -3596,7 +3596,7 @@
     },
     "node_modules/@npmcli/redact": {
       "version": "4.0.0",
-      "resolved": "https://npm.sinequa.com/@npmcli/redact/-/redact-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@npmcli/redact/-/redact-4.0.0.tgz",
       "integrity": "sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==",
       "dev": true,
       "license": "ISC",
@@ -3606,7 +3606,7 @@
     },
     "node_modules/@npmcli/run-script": {
       "version": "10.0.3",
-      "resolved": "https://npm.sinequa.com/@npmcli/run-script/-/run-script-10.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-10.0.3.tgz",
       "integrity": "sha512-ER2N6itRkzWbbtVmZ9WKaWxVlKlOeBFF1/7xx+KA5J1xKa4JjUwBdb6tDpk0v1qA+d+VDwHI9qmLcXSWcmi+Rw==",
       "dev": true,
       "license": "ISC",
@@ -3624,7 +3624,7 @@
     },
     "node_modules/@npmcli/run-script/node_modules/isexe": {
       "version": "3.1.1",
-      "resolved": "https://npm.sinequa.com/isexe/-/isexe-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
       "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
       "dev": true,
       "license": "ISC",
@@ -3634,7 +3634,7 @@
     },
     "node_modules/@npmcli/run-script/node_modules/proc-log": {
       "version": "6.1.0",
-      "resolved": "https://npm.sinequa.com/proc-log/-/proc-log-6.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
       "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
       "dev": true,
       "license": "ISC",
@@ -3644,7 +3644,7 @@
     },
     "node_modules/@npmcli/run-script/node_modules/which": {
       "version": "6.0.0",
-      "resolved": "https://npm.sinequa.com/which/-/which-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.0.tgz",
       "integrity": "sha512-f+gEpIKMR9faW/JgAgPK1D7mekkFoqbmiwvNzuhsHetni20QSgzg9Vhn0g2JSJkkfehQnqdUAx7/e15qS1lPxg==",
       "dev": true,
       "license": "ISC",
@@ -3660,7 +3660,7 @@
     },
     "node_modules/@oxc-project/types": {
       "version": "0.123.0",
-      "resolved": "https://npm.sinequa.com/@oxc-project/types/-/types-0.123.0.tgz",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.123.0.tgz",
       "integrity": "sha512-YtECP/y8Mj1lSHiUWGSRzy/C6teUKlS87dEfuVKT09LgQbUsBW1rNg+MiJ4buGu3yuADV60gbIvo9/HplA56Ew==",
       "dev": true,
       "license": "MIT",
@@ -3670,7 +3670,7 @@
     },
     "node_modules/@parcel/watcher": {
       "version": "2.5.1",
-      "resolved": "https://npm.sinequa.com/@parcel/watcher/-/watcher-2.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
       "integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
       "dev": true,
       "hasInstallScript": true,
@@ -3707,7 +3707,7 @@
     },
     "node_modules/@parcel/watcher-android-arm64": {
       "version": "2.5.1",
-      "resolved": "https://npm.sinequa.com/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.1.tgz",
       "integrity": "sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==",
       "cpu": [
         "arm64"
@@ -3728,7 +3728,7 @@
     },
     "node_modules/@parcel/watcher-darwin-arm64": {
       "version": "2.5.1",
-      "resolved": "https://npm.sinequa.com/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.1.tgz",
       "integrity": "sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw==",
       "cpu": [
         "arm64"
@@ -3749,7 +3749,7 @@
     },
     "node_modules/@parcel/watcher-darwin-x64": {
       "version": "2.5.1",
-      "resolved": "https://npm.sinequa.com/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.1.tgz",
       "integrity": "sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==",
       "cpu": [
         "x64"
@@ -3770,7 +3770,7 @@
     },
     "node_modules/@parcel/watcher-freebsd-x64": {
       "version": "2.5.1",
-      "resolved": "https://npm.sinequa.com/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.1.tgz",
       "integrity": "sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ==",
       "cpu": [
         "x64"
@@ -3791,7 +3791,7 @@
     },
     "node_modules/@parcel/watcher-linux-arm-glibc": {
       "version": "2.5.1",
-      "resolved": "https://npm.sinequa.com/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.1.tgz",
       "integrity": "sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA==",
       "cpu": [
         "arm"
@@ -3812,7 +3812,7 @@
     },
     "node_modules/@parcel/watcher-linux-arm-musl": {
       "version": "2.5.1",
-      "resolved": "https://npm.sinequa.com/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.1.tgz",
       "integrity": "sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==",
       "cpu": [
         "arm"
@@ -3833,7 +3833,7 @@
     },
     "node_modules/@parcel/watcher-linux-arm64-glibc": {
       "version": "2.5.1",
-      "resolved": "https://npm.sinequa.com/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.1.tgz",
       "integrity": "sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==",
       "cpu": [
         "arm64"
@@ -3854,7 +3854,7 @@
     },
     "node_modules/@parcel/watcher-linux-arm64-musl": {
       "version": "2.5.1",
-      "resolved": "https://npm.sinequa.com/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.1.tgz",
       "integrity": "sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==",
       "cpu": [
         "arm64"
@@ -3875,7 +3875,7 @@
     },
     "node_modules/@parcel/watcher-linux-x64-glibc": {
       "version": "2.5.1",
-      "resolved": "https://npm.sinequa.com/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz",
       "integrity": "sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==",
       "cpu": [
         "x64"
@@ -3896,7 +3896,7 @@
     },
     "node_modules/@parcel/watcher-linux-x64-musl": {
       "version": "2.5.1",
-      "resolved": "https://npm.sinequa.com/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz",
       "integrity": "sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==",
       "cpu": [
         "x64"
@@ -3917,7 +3917,7 @@
     },
     "node_modules/@parcel/watcher-win32-arm64": {
       "version": "2.5.1",
-      "resolved": "https://npm.sinequa.com/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.1.tgz",
       "integrity": "sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==",
       "cpu": [
         "arm64"
@@ -3938,7 +3938,7 @@
     },
     "node_modules/@parcel/watcher-win32-ia32": {
       "version": "2.5.1",
-      "resolved": "https://npm.sinequa.com/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.1.tgz",
       "integrity": "sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ==",
       "cpu": [
         "ia32"
@@ -3959,7 +3959,7 @@
     },
     "node_modules/@parcel/watcher-win32-x64": {
       "version": "2.5.1",
-      "resolved": "https://npm.sinequa.com/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.1.tgz",
       "integrity": "sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==",
       "cpu": [
         "x64"
@@ -3980,7 +3980,7 @@
     },
     "node_modules/@parcel/watcher/node_modules/detect-libc": {
       "version": "1.0.3",
-      "resolved": "https://npm.sinequa.com/detect-libc/-/detect-libc-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
       "dev": true,
       "license": "Apache-2.0",
@@ -3994,7 +3994,7 @@
     },
     "node_modules/@parcel/watcher/node_modules/node-addon-api": {
       "version": "7.1.1",
-      "resolved": "https://npm.sinequa.com/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "dev": true,
       "license": "MIT",
@@ -4002,7 +4002,7 @@
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
-      "resolved": "https://npm.sinequa.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
       "license": "MIT",
       "optional": true,
@@ -4012,7 +4012,7 @@
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.13",
-      "resolved": "https://npm.sinequa.com/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.13.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.13.tgz",
       "integrity": "sha512-5ZiiecKH2DXAVJTNN13gNMUcCDg4Jy8ZjbXEsPnqa248wgOVeYRX0iqXXD5Jz4bI9BFHgKsI2qmyJynstbmr+g==",
       "cpu": [
         "arm64"
@@ -4029,7 +4029,7 @@
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
       "version": "1.0.0-rc.13",
-      "resolved": "https://npm.sinequa.com/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.13.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.13.tgz",
       "integrity": "sha512-tz/v/8G77seu8zAB3A5sK3UFoOl06zcshEzhUO62sAEtrEuW/H1CcyoupOrD+NbQJytYgA4CppXPzlrmp4JZKA==",
       "cpu": [
         "arm64"
@@ -4046,7 +4046,7 @@
     },
     "node_modules/@rolldown/binding-darwin-x64": {
       "version": "1.0.0-rc.13",
-      "resolved": "https://npm.sinequa.com/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.13.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.13.tgz",
       "integrity": "sha512-8DakphqOz8JrMYWTJmWA+vDJxut6LijZ8Xcdc4flOlAhU7PNVwo2MaWBF9iXjJAPo5rC/IxEFZDhJ3GC7NHvug==",
       "cpu": [
         "x64"
@@ -4063,7 +4063,7 @@
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
       "version": "1.0.0-rc.13",
-      "resolved": "https://npm.sinequa.com/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.13.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.13.tgz",
       "integrity": "sha512-4wBQFfjDuXYN/SVI8inBF3Aa+isq40rc6VMFbk5jcpolUBTe5cYnMsHZ51nFWsx3PVyyNN3vgoESki0Hmr/4BA==",
       "cpu": [
         "x64"
@@ -4080,7 +4080,7 @@
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
       "version": "1.0.0-rc.13",
-      "resolved": "https://npm.sinequa.com/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.13.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.13.tgz",
       "integrity": "sha512-JW/e4yPIXLms+jmnbwwy5LA/LxVwZUWLN8xug+V200wzaVi5TEGIWQlh8o91gWYFxW609euI98OCCemmWGuPrw==",
       "cpu": [
         "arm"
@@ -4097,7 +4097,7 @@
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
       "version": "1.0.0-rc.13",
-      "resolved": "https://npm.sinequa.com/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.13.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.13.tgz",
       "integrity": "sha512-ZfKWpXiUymDnavepCaM6KG/uGydJ4l2nBmMxg60Ci4CbeefpqjPWpfaZM7PThOhk2dssqBAcwLc6rAyr0uTdXg==",
       "cpu": [
         "arm64"
@@ -4114,7 +4114,7 @@
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
       "version": "1.0.0-rc.13",
-      "resolved": "https://npm.sinequa.com/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.13.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.13.tgz",
       "integrity": "sha512-bmRg3O6Z0gq9yodKKWCIpnlH051sEfdVwt+6m5UDffAQMUUqU0xjnQqqAUm+Gu7ofAAly9DqiQDtKu2nPDEABA==",
       "cpu": [
         "arm64"
@@ -4131,7 +4131,7 @@
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
       "version": "1.0.0-rc.13",
-      "resolved": "https://npm.sinequa.com/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.13.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.13.tgz",
       "integrity": "sha512-8Wtnbw4k7pMYN9B/mOEAsQ8HOiq7AZ31Ig4M9BKn2So4xRaFEhtCSa4ZJaOutOWq50zpgR4N5+L/opnlaCx8wQ==",
       "cpu": [
         "ppc64"
@@ -4148,7 +4148,7 @@
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
       "version": "1.0.0-rc.13",
-      "resolved": "https://npm.sinequa.com/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.13.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.13.tgz",
       "integrity": "sha512-D/0Nlo8mQuxSMohNJUF2lDXWRsFDsHldfRRgD9bRgktj+EndGPj4DOV37LqDKPYS+osdyhZEH7fTakTAEcW7qg==",
       "cpu": [
         "s390x"
@@ -4165,7 +4165,7 @@
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
       "version": "1.0.0-rc.13",
-      "resolved": "https://npm.sinequa.com/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.13.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.13.tgz",
       "integrity": "sha512-eRrPvat2YaVQcwwKi/JzOP6MKf1WRnOCr+VaI3cTWz3ZoLcP/654z90lVCJ4dAuMEpPdke0n+qyAqXDZdIC4rA==",
       "cpu": [
         "x64"
@@ -4182,7 +4182,7 @@
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
       "version": "1.0.0-rc.13",
-      "resolved": "https://npm.sinequa.com/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.13.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.13.tgz",
       "integrity": "sha512-PsdONiFRp8hR8KgVjTWjZ9s7uA3uueWL0t74/cKHfM4dR5zXYv4AjB8BvA+QDToqxAFg4ZkcVEqeu5F7inoz5w==",
       "cpu": [
         "x64"
@@ -4199,7 +4199,7 @@
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
       "version": "1.0.0-rc.13",
-      "resolved": "https://npm.sinequa.com/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.13.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.13.tgz",
       "integrity": "sha512-hCNXgC5dI3TVOLrPT++PKFNZ+1EtS0mLQwfXXXSUD/+rGlB65gZDwN/IDuxLpQP4x8RYYHqGomlUXzpO8aVI2w==",
       "cpu": [
         "arm64"
@@ -4216,7 +4216,7 @@
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
       "version": "1.0.0-rc.13",
-      "resolved": "https://npm.sinequa.com/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.13.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.13.tgz",
       "integrity": "sha512-viLS5C5et8NFtLWw9Sw3M/w4vvnVkbWkO7wSNh3C+7G1+uCkGpr6PcjNDSFcNtmXY/4trjPBqUfcOL+P3sWy/g==",
       "cpu": [
         "wasm32"
@@ -4235,7 +4235,7 @@
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
       "version": "1.0.0-rc.13",
-      "resolved": "https://npm.sinequa.com/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.13.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.13.tgz",
       "integrity": "sha512-Fqa3Tlt1xL4wzmAYxGNFV36Hb+VfPc9PYU+E25DAnswXv3ODDu/yyWjQDbXMo5AGWkQVjLgQExuVu8I/UaZhPQ==",
       "cpu": [
         "arm64"
@@ -4252,7 +4252,7 @@
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
       "version": "1.0.0-rc.13",
-      "resolved": "https://npm.sinequa.com/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.13.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.13.tgz",
       "integrity": "sha512-/pLI5kPkGEi44TDlnbio3St/5gUFeN51YWNAk/Gnv6mEQBOahRBh52qVFVBpmrnU01n2yysvBML9Ynu7K4kGAQ==",
       "cpu": [
         "x64"
@@ -4269,14 +4269,14 @@
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.13",
-      "resolved": "https://npm.sinequa.com/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.13.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.13.tgz",
       "integrity": "sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.59.0",
-      "resolved": "https://npm.sinequa.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
       "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
       "cpu": [
         "arm"
@@ -4290,7 +4290,7 @@
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.59.0",
-      "resolved": "https://npm.sinequa.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
       "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
       "cpu": [
         "arm64"
@@ -4304,7 +4304,7 @@
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.59.0",
-      "resolved": "https://npm.sinequa.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
       "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
       "cpu": [
         "arm64"
@@ -4318,7 +4318,7 @@
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.59.0",
-      "resolved": "https://npm.sinequa.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
       "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
       "cpu": [
         "x64"
@@ -4332,7 +4332,7 @@
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.59.0",
-      "resolved": "https://npm.sinequa.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
       "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
       "cpu": [
         "arm64"
@@ -4346,7 +4346,7 @@
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.59.0",
-      "resolved": "https://npm.sinequa.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
       "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
       "cpu": [
         "x64"
@@ -4360,7 +4360,7 @@
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.59.0",
-      "resolved": "https://npm.sinequa.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
       "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
       "cpu": [
         "arm"
@@ -4374,7 +4374,7 @@
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.59.0",
-      "resolved": "https://npm.sinequa.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
       "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
       "cpu": [
         "arm"
@@ -4388,7 +4388,7 @@
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.59.0",
-      "resolved": "https://npm.sinequa.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
       "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
       "cpu": [
         "arm64"
@@ -4402,7 +4402,7 @@
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.59.0",
-      "resolved": "https://npm.sinequa.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
       "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
       "cpu": [
         "arm64"
@@ -4416,7 +4416,7 @@
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.59.0",
-      "resolved": "https://npm.sinequa.com/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
       "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
       "cpu": [
         "loong64"
@@ -4430,7 +4430,7 @@
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.59.0",
-      "resolved": "https://npm.sinequa.com/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
       "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
       "cpu": [
         "loong64"
@@ -4444,7 +4444,7 @@
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.59.0",
-      "resolved": "https://npm.sinequa.com/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
       "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
       "cpu": [
         "ppc64"
@@ -4458,7 +4458,7 @@
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.59.0",
-      "resolved": "https://npm.sinequa.com/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
       "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
       "cpu": [
         "ppc64"
@@ -4472,7 +4472,7 @@
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.59.0",
-      "resolved": "https://npm.sinequa.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
       "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
       "cpu": [
         "riscv64"
@@ -4486,7 +4486,7 @@
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.59.0",
-      "resolved": "https://npm.sinequa.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
       "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
       "cpu": [
         "riscv64"
@@ -4500,7 +4500,7 @@
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.59.0",
-      "resolved": "https://npm.sinequa.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
       "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
       "cpu": [
         "s390x"
@@ -4514,7 +4514,7 @@
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.59.0",
-      "resolved": "https://npm.sinequa.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
       "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
       "cpu": [
         "x64"
@@ -4528,7 +4528,7 @@
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.59.0",
-      "resolved": "https://npm.sinequa.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
       "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
       "cpu": [
         "x64"
@@ -4542,7 +4542,7 @@
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.59.0",
-      "resolved": "https://npm.sinequa.com/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
       "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
       "cpu": [
         "x64"
@@ -4556,7 +4556,7 @@
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.59.0",
-      "resolved": "https://npm.sinequa.com/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
       "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
       "cpu": [
         "arm64"
@@ -4570,7 +4570,7 @@
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.59.0",
-      "resolved": "https://npm.sinequa.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
       "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
       "cpu": [
         "arm64"
@@ -4584,7 +4584,7 @@
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.59.0",
-      "resolved": "https://npm.sinequa.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
       "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
       "cpu": [
         "ia32"
@@ -4598,7 +4598,7 @@
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.59.0",
-      "resolved": "https://npm.sinequa.com/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
       "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
       "cpu": [
         "x64"
@@ -4612,7 +4612,7 @@
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.59.0",
-      "resolved": "https://npm.sinequa.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
       "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
       "cpu": [
         "x64"
@@ -4626,7 +4626,7 @@
     },
     "node_modules/@schematics/angular": {
       "version": "20.3.22",
-      "resolved": "https://npm.sinequa.com/@schematics/angular/-/angular-20.3.22.tgz",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-20.3.22.tgz",
       "integrity": "sha512-wXTdFaPIBnSSNj/m0kclvPCYQOc2EGTQN1+Q3j9RIghS9gKgPxI1unSfgieJldZWKzcl8+WdB2zUuDzE7tEshQ==",
       "dev": true,
       "license": "MIT",
@@ -4643,7 +4643,7 @@
     },
     "node_modules/@sigstore/bundle": {
       "version": "4.0.0",
-      "resolved": "https://npm.sinequa.com/@sigstore/bundle/-/bundle-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-4.0.0.tgz",
       "integrity": "sha512-NwCl5Y0V6Di0NexvkTqdoVfmjTaQwoLM236r89KEojGmq/jMls8S+zb7yOwAPdXvbwfKDlP+lmXgAL4vKSQT+A==",
       "dev": true,
       "license": "Apache-2.0",
@@ -4656,7 +4656,7 @@
     },
     "node_modules/@sigstore/core": {
       "version": "3.1.0",
-      "resolved": "https://npm.sinequa.com/@sigstore/core/-/core-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@sigstore/core/-/core-3.1.0.tgz",
       "integrity": "sha512-o5cw1QYhNQ9IroioJxpzexmPjfCe7gzafd2RY3qnMpxr4ZEja+Jad/U8sgFpaue6bOaF+z7RVkyKVV44FN+N8A==",
       "dev": true,
       "license": "Apache-2.0",
@@ -4666,7 +4666,7 @@
     },
     "node_modules/@sigstore/protobuf-specs": {
       "version": "0.5.0",
-      "resolved": "https://npm.sinequa.com/@sigstore/protobuf-specs/-/protobuf-specs-0.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/@sigstore/protobuf-specs/-/protobuf-specs-0.5.0.tgz",
       "integrity": "sha512-MM8XIwUjN2bwvCg1QvrMtbBmpcSHrkhFSCu1D11NyPvDQ25HEc4oG5/OcQfd/Tlf/OxmKWERDj0zGE23jQaMwA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -4676,7 +4676,7 @@
     },
     "node_modules/@sigstore/sign": {
       "version": "4.1.0",
-      "resolved": "https://npm.sinequa.com/@sigstore/sign/-/sign-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-4.1.0.tgz",
       "integrity": "sha512-Vx1RmLxLGnSUqx/o5/VsCjkuN5L7y+vxEEwawvc7u+6WtX2W4GNa7b9HEjmcRWohw/d6BpATXmvOwc78m+Swdg==",
       "dev": true,
       "license": "Apache-2.0",
@@ -4694,7 +4694,7 @@
     },
     "node_modules/@sigstore/sign/node_modules/proc-log": {
       "version": "6.1.0",
-      "resolved": "https://npm.sinequa.com/proc-log/-/proc-log-6.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
       "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
       "dev": true,
       "license": "ISC",
@@ -4704,7 +4704,7 @@
     },
     "node_modules/@sigstore/tuf": {
       "version": "4.0.1",
-      "resolved": "https://npm.sinequa.com/@sigstore/tuf/-/tuf-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@sigstore/tuf/-/tuf-4.0.1.tgz",
       "integrity": "sha512-OPZBg8y5Vc9yZjmWCHrlWPMBqW5yd8+wFNl+thMdtcWz3vjVSoJQutF8YkrzI0SLGnkuFof4HSsWUhXrf219Lw==",
       "dev": true,
       "license": "Apache-2.0",
@@ -4718,7 +4718,7 @@
     },
     "node_modules/@sigstore/verify": {
       "version": "3.1.0",
-      "resolved": "https://npm.sinequa.com/@sigstore/verify/-/verify-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@sigstore/verify/-/verify-3.1.0.tgz",
       "integrity": "sha512-mNe0Iigql08YupSOGv197YdHpPPr+EzDZmfCgMc7RPNaZTw5aLN01nBl6CHJOh3BGtnMIj83EeN4butBchc8Ag==",
       "dev": true,
       "license": "Apache-2.0",
@@ -4733,8 +4733,8 @@
     },
     "node_modules/@sinequa/assistant": {
       "version": "3.10.13",
-      "resolved": "https://npm.sinequa.com/@sinequa/assistant/-/assistant-3.10.13.tgz",
-      "integrity": "sha512-D9YsVwDpxe4z9MWXM9GnUaC/w0XuCOq0QqHjk8CJipEyFOe7D4OwpKfHsD9WolKxuek0rhbGdPnZlbkQ+NFRIA==",
+      "resolved": "https://registry.npmjs.org/@sinequa/assistant/-/assistant-3.10.13.tgz",
+      "integrity": "sha512-a6quP058dL4jMjxirE+S/5JGT1vDkxc0Wqsub2PFIwACB8qUNbBq7aujckm8sT0o1gAXZMPQGZKRcGv83rBiVg==",
       "bundleDependencies": [
         "zod"
       ],
@@ -4759,12 +4759,12 @@
     },
     "node_modules/@sinequa/atomic": {
       "version": "1.1.0",
-      "resolved": "https://npm.sinequa.com/@sinequa/atomic/-/atomic-1.1.0.tgz",
-      "integrity": "sha512-5/A6LWq3t2qsMmDGH5ldof91R8AFuIVKEp9SrR6clTzsXHowfmwuA8V99VARklo9DPHq6ohgDUjP7t1V7SlhzA=="
+      "resolved": "https://registry.npmjs.org/@sinequa/atomic/-/atomic-1.1.0.tgz",
+      "integrity": "sha512-uBizqE/okk+FnSlY8S1CUDNW9U2dtVHQEHPENUEipvR94+KaQ5wAeWC0q989I5NslyvoiEPSkWD5R/I69XEB/g=="
     },
     "node_modules/@sinequa/atomic-angular": {
       "version": "1.0.4",
-      "resolved": "https://npm.sinequa.com/@sinequa/atomic-angular/-/atomic-angular-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/@sinequa/atomic-angular/-/atomic-angular-1.0.4.tgz",
       "integrity": "sha512-fczP6Tw3rjMdMIiTlXgZElYYWOXeSa/4e6w9Vr57Im/Crg8ftdZexhrrntalarq50Wlqi9mzKcLNphYEK2qVAg==",
       "dependencies": {
         "@angular-architects/ngrx-toolkit": "^20.0.0",
@@ -4782,7 +4782,7 @@
     },
     "node_modules/@sinequa/atomic-angular/node_modules/highlight-words": {
       "version": "2.0.0",
-      "resolved": "https://npm.sinequa.com/highlight-words/-/highlight-words-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/highlight-words/-/highlight-words-2.0.0.tgz",
       "integrity": "sha512-If5n+IhSBRXTScE7wl16VPmd+44Vy7kof24EdqhjsZsDuHikpv1OCagVcJFpB4fS4UPUniedlWqrjIO8vWOsIQ==",
       "license": "MIT",
       "engines": {
@@ -4792,7 +4792,7 @@
     },
     "node_modules/@sinequa/ui": {
       "version": "1.0.0",
-      "resolved": "https://npm.sinequa.com/@sinequa/ui/-/ui-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@sinequa/ui/-/ui-1.0.0.tgz",
       "integrity": "sha512-0lbOBgAaOddA2J8Gg015eSLoz1Y1JucXv67i2W6Lvgw54ncfVOhWd88F2Iq10KG/OxKbNODjLZKjm9yM2Gur6w==",
       "dependencies": {
         "@floating-ui/dom": "^1.6.3",
@@ -4807,7 +4807,7 @@
     },
     "node_modules/@sinequa/ui/node_modules/tailwind-merge": {
       "version": "3.3.1",
-      "resolved": "https://npm.sinequa.com/tailwind-merge/-/tailwind-merge-3.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.1.tgz",
       "integrity": "sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==",
       "license": "MIT",
       "funding": {
@@ -4817,7 +4817,7 @@
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.1.10",
-      "resolved": "https://npm.sinequa.com/@tailwindcss/node/-/node-4.1.10.tgz",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.10.tgz",
       "integrity": "sha512-2ACf1znY5fpRBwRhMgj9ZXvb2XZW8qs+oTfotJ2C5xR0/WNL7UHZ7zXl6s+rUqedL1mNi+0O+WQr5awGowS3PQ==",
       "license": "MIT",
       "dependencies": {
@@ -4832,7 +4832,7 @@
     },
     "node_modules/@tailwindcss/oxide": {
       "version": "4.1.10",
-      "resolved": "https://npm.sinequa.com/@tailwindcss/oxide/-/oxide-4.1.10.tgz",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.10.tgz",
       "integrity": "sha512-v0C43s7Pjw+B9w21htrQwuFObSkio2aV/qPx/mhrRldbqxbWJK6KizM+q7BF1/1CmuLqZqX3CeYF7s7P9fbA8Q==",
       "hasInstallScript": true,
       "license": "MIT",
@@ -4860,7 +4860,7 @@
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
       "version": "4.1.10",
-      "resolved": "https://npm.sinequa.com/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.10.tgz",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.10.tgz",
       "integrity": "sha512-VGLazCoRQ7rtsCzThaI1UyDu/XRYVyH4/EWiaSX6tFglE+xZB5cvtC5Omt0OQ+FfiIVP98su16jDVHDEIuH4iQ==",
       "cpu": [
         "arm64"
@@ -4876,7 +4876,7 @@
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
       "version": "4.1.10",
-      "resolved": "https://npm.sinequa.com/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.10.tgz",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.10.tgz",
       "integrity": "sha512-ZIFqvR1irX2yNjWJzKCqTCcHZbgkSkSkZKbRM3BPzhDL/18idA8uWCoopYA2CSDdSGFlDAxYdU2yBHwAwx8euQ==",
       "cpu": [
         "arm64"
@@ -4892,7 +4892,7 @@
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
       "version": "4.1.10",
-      "resolved": "https://npm.sinequa.com/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.10.tgz",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.10.tgz",
       "integrity": "sha512-eCA4zbIhWUFDXoamNztmS0MjXHSEJYlvATzWnRiTqJkcUteSjO94PoRHJy1Xbwp9bptjeIxxBHh+zBWFhttbrQ==",
       "cpu": [
         "x64"
@@ -4908,7 +4908,7 @@
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
       "version": "4.1.10",
-      "resolved": "https://npm.sinequa.com/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.10.tgz",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.10.tgz",
       "integrity": "sha512-8/392Xu12R0cc93DpiJvNpJ4wYVSiciUlkiOHOSOQNH3adq9Gi/dtySK7dVQjXIOzlpSHjeCL89RUUI8/GTI6g==",
       "cpu": [
         "x64"
@@ -4924,7 +4924,7 @@
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
       "version": "4.1.10",
-      "resolved": "https://npm.sinequa.com/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.10.tgz",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.10.tgz",
       "integrity": "sha512-t9rhmLT6EqeuPT+MXhWhlRYIMSfh5LZ6kBrC4FS6/+M1yXwfCtp24UumgCWOAJVyjQwG+lYva6wWZxrfvB+NhQ==",
       "cpu": [
         "arm"
@@ -4940,7 +4940,7 @@
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
       "version": "4.1.10",
-      "resolved": "https://npm.sinequa.com/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.10.tgz",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.10.tgz",
       "integrity": "sha512-3oWrlNlxLRxXejQ8zImzrVLuZ/9Z2SeKoLhtCu0hpo38hTO2iL86eFOu4sVR8cZc6n3z7eRXXqtHJECa6mFOvA==",
       "cpu": [
         "arm64"
@@ -4956,7 +4956,7 @@
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
       "version": "4.1.10",
-      "resolved": "https://npm.sinequa.com/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.10.tgz",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.10.tgz",
       "integrity": "sha512-saScU0cmWvg/Ez4gUmQWr9pvY9Kssxt+Xenfx1LG7LmqjcrvBnw4r9VjkFcqmbBb7GCBwYNcZi9X3/oMda9sqQ==",
       "cpu": [
         "arm64"
@@ -4972,7 +4972,7 @@
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
       "version": "4.1.10",
-      "resolved": "https://npm.sinequa.com/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.10.tgz",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.10.tgz",
       "integrity": "sha512-/G3ao/ybV9YEEgAXeEg28dyH6gs1QG8tvdN9c2MNZdUXYBaIY/Gx0N6RlJzfLy/7Nkdok4kaxKPHKJUlAaoTdA==",
       "cpu": [
         "x64"
@@ -4988,7 +4988,7 @@
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
       "version": "4.1.10",
-      "resolved": "https://npm.sinequa.com/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.10.tgz",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.10.tgz",
       "integrity": "sha512-LNr7X8fTiKGRtQGOerSayc2pWJp/9ptRYAa4G+U+cjw9kJZvkopav1AQc5HHD+U364f71tZv6XamaHKgrIoVzA==",
       "cpu": [
         "x64"
@@ -5004,7 +5004,7 @@
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
       "version": "4.1.10",
-      "resolved": "https://npm.sinequa.com/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.10.tgz",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.10.tgz",
       "integrity": "sha512-d6ekQpopFQJAcIK2i7ZzWOYGZ+A6NzzvQ3ozBvWFdeyqfOZdYHU66g5yr+/HC4ipP1ZgWsqa80+ISNILk+ae/Q==",
       "bundleDependencies": [
         "@napi-rs/wasm-runtime",
@@ -5087,7 +5087,7 @@
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.10",
-      "resolved": "https://npm.sinequa.com/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.10.tgz",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.10.tgz",
       "integrity": "sha512-i1Iwg9gRbwNVOCYmnigWCCgow8nDWSFmeTUU5nbNx3rqbe4p0kRbEqLwLJbYZKmSSp23g4N6rCDmm7OuPBXhDA==",
       "cpu": [
         "arm64"
@@ -5103,7 +5103,7 @@
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
       "version": "4.1.10",
-      "resolved": "https://npm.sinequa.com/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.10.tgz",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.10.tgz",
       "integrity": "sha512-sGiJTjcBSfGq2DVRtaSljq5ZgZS2SDHSIfhOylkBvHVjwOsodBhnb3HdmiKkVuUGKD0I7G63abMOVaskj1KpOA==",
       "cpu": [
         "x64"
@@ -5119,7 +5119,7 @@
     },
     "node_modules/@tailwindcss/postcss": {
       "version": "4.1.10",
-      "resolved": "https://npm.sinequa.com/@tailwindcss/postcss/-/postcss-4.1.10.tgz",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.1.10.tgz",
       "integrity": "sha512-B+7r7ABZbkXJwpvt2VMnS6ujcDoR2OOcFaqrLIo1xbcdxje4Vf+VgJdBzNNbrAjBj/rLZ66/tlQ1knIGNLKOBQ==",
       "license": "MIT",
       "dependencies": {
@@ -5132,7 +5132,7 @@
     },
     "node_modules/@tailwindcss/typography": {
       "version": "0.5.16",
-      "resolved": "https://npm.sinequa.com/@tailwindcss/typography/-/typography-0.5.16.tgz",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.16.tgz",
       "integrity": "sha512-0wDLwCVF5V3x3b1SGXPCDcdsbDHMBe+lkFzBRaHeLvNi+nrrnZ1lA18u+OTWO8iSWU2GxUOCvlXtDuqftc1oiA==",
       "dev": true,
       "license": "MIT",
@@ -5148,7 +5148,7 @@
     },
     "node_modules/@tanstack/angular-query-experimental": {
       "version": "5.80.10",
-      "resolved": "https://npm.sinequa.com/@tanstack/angular-query-experimental/-/angular-query-experimental-5.80.10.tgz",
+      "resolved": "https://registry.npmjs.org/@tanstack/angular-query-experimental/-/angular-query-experimental-5.80.10.tgz",
       "integrity": "sha512-4GioADPuUpPMVVTNvScSai9anBY3HrWyglP6/hfx4GKsO44EFL9xX4iUG6rJG7MjtxkbrgVxcu6v0+8stCw2hg==",
       "license": "MIT",
       "dependencies": {
@@ -5166,7 +5166,7 @@
     },
     "node_modules/@tanstack/angular-virtual": {
       "version": "4.0.7",
-      "resolved": "https://npm.sinequa.com/@tanstack/angular-virtual/-/angular-virtual-4.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/@tanstack/angular-virtual/-/angular-virtual-4.0.7.tgz",
       "integrity": "sha512-gyxnhXsazJjijn38MMn91UOFsnJ3iDMMkVkGwncOvR+/5w9dP3pBxQQglwVrqgCOCvQxvo6OjPxkFEM5LTZ/pQ==",
       "license": "MIT",
       "dependencies": {
@@ -5186,7 +5186,7 @@
     },
     "node_modules/@tanstack/query-core": {
       "version": "5.80.10",
-      "resolved": "https://npm.sinequa.com/@tanstack/query-core/-/query-core-5.80.10.tgz",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.80.10.tgz",
       "integrity": "sha512-mUNQOtzxkjL6jLbyChZoSBP6A5gQDVRUiPvW+/zw/9ftOAz+H754zCj3D8PwnzPKyHzGkQ9JbH48ukhym9LK1Q==",
       "license": "MIT",
       "funding": {
@@ -5196,7 +5196,7 @@
     },
     "node_modules/@tanstack/query-devtools": {
       "version": "5.80.0",
-      "resolved": "https://npm.sinequa.com/@tanstack/query-devtools/-/query-devtools-5.80.0.tgz",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.80.0.tgz",
       "integrity": "sha512-D6gH4asyjaoXrCOt5vG5Og/YSj0D/TxwNQgtLJIgWbhbWCC/emu2E92EFoVHh4ppVWg1qT2gKHvKyQBEFZhCuA==",
       "license": "MIT",
       "funding": {
@@ -5206,7 +5206,7 @@
     },
     "node_modules/@tanstack/virtual-core": {
       "version": "3.13.19",
-      "resolved": "https://npm.sinequa.com/@tanstack/virtual-core/-/virtual-core-3.13.19.tgz",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.19.tgz",
       "integrity": "sha512-/BMP7kNhzKOd7wnDeB8NrIRNLwkf5AhCYCvtfZV2GXWbBieFm/el0n6LOAXlTi6ZwHICSNnQcIxRCWHrLzDY+g==",
       "license": "MIT",
       "funding": {
@@ -5216,7 +5216,7 @@
     },
     "node_modules/@tufjs/canonical-json": {
       "version": "2.0.0",
-      "resolved": "https://npm.sinequa.com/@tufjs/canonical-json/-/canonical-json-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@tufjs/canonical-json/-/canonical-json-2.0.0.tgz",
       "integrity": "sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA==",
       "dev": true,
       "license": "MIT",
@@ -5226,7 +5226,7 @@
     },
     "node_modules/@tufjs/models": {
       "version": "4.1.0",
-      "resolved": "https://npm.sinequa.com/@tufjs/models/-/models-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@tufjs/models/-/models-4.1.0.tgz",
       "integrity": "sha512-Y8cK9aggNRsqJVaKUlEYs4s7CvQ1b1ta2DVPyAimb0I2qhzjNk+A+mxvll/klL0RlfuIUei8BF7YWiua4kQqww==",
       "dev": true,
       "license": "MIT",
@@ -5240,7 +5240,7 @@
     },
     "node_modules/@tufjs/models/node_modules/balanced-match": {
       "version": "4.0.4",
-      "resolved": "https://npm.sinequa.com/balanced-match/-/balanced-match-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
       "license": "MIT",
@@ -5250,7 +5250,7 @@
     },
     "node_modules/@tufjs/models/node_modules/brace-expansion": {
       "version": "5.0.5",
-      "resolved": "https://npm.sinequa.com/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
       "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
@@ -5263,7 +5263,7 @@
     },
     "node_modules/@tufjs/models/node_modules/minimatch": {
       "version": "10.2.4",
-      "resolved": "https://npm.sinequa.com/minimatch/-/minimatch-10.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
       "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -5279,7 +5279,7 @@
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
-      "resolved": "https://npm.sinequa.com/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
       "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
       "dev": true,
       "license": "MIT",
@@ -5290,28 +5290,28 @@
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
-      "resolved": "https://npm.sinequa.com/@types/estree/-/estree-1.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/flowjs": {
       "version": "2.13.14",
-      "resolved": "https://npm.sinequa.com/@types/flowjs/-/flowjs-2.13.14.tgz",
+      "resolved": "https://registry.npmjs.org/@types/flowjs/-/flowjs-2.13.14.tgz",
       "integrity": "sha512-OlZFH9hbOq5B+GeBjcM3UvvSailseRT+sKoi9jyFFczvvS1n1LTiTKJysDSLVWnUvGD+tsn7kxb6eC2uaJD+Zw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/linkify-it": {
       "version": "5.0.0",
-      "resolved": "https://npm.sinequa.com/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
       "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/markdown-it": {
       "version": "14.1.2",
-      "resolved": "https://npm.sinequa.com/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "dev": true,
       "license": "MIT",
@@ -5322,14 +5322,14 @@
     },
     "node_modules/@types/mdurl": {
       "version": "2.0.0",
-      "resolved": "https://npm.sinequa.com/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "22.15.32",
-      "resolved": "https://npm.sinequa.com/@types/node/-/node-22.15.32.tgz",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.32.tgz",
       "integrity": "sha512-3jigKqgSjsH6gYZv2nEsqdXfZqIFGAV36XYYjf9KGZ3PSG+IhLecqPnI310RvjutyMwifE2hhhNEklOUrvx/wA==",
       "dev": true,
       "license": "MIT",
@@ -5339,14 +5339,14 @@
     },
     "node_modules/@types/vanillajs-datepicker": {
       "version": "1.3.5",
-      "resolved": "https://npm.sinequa.com/@types/vanillajs-datepicker/-/vanillajs-datepicker-1.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/@types/vanillajs-datepicker/-/vanillajs-datepicker-1.3.5.tgz",
       "integrity": "sha512-QEFhLVACZEyvCd/N/28JhVMMa4u3Z6QvX9InJhcBNjV0VevQ4ZgYrc1RqH3bsstJH6pB0Uy75/nwCkx8j4NIIQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@vitejs/plugin-basic-ssl": {
       "version": "2.1.0",
-      "resolved": "https://npm.sinequa.com/@vitejs/plugin-basic-ssl/-/plugin-basic-ssl-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-basic-ssl/-/plugin-basic-ssl-2.1.0.tgz",
       "integrity": "sha512-dOxxrhgyDIEUADhb/8OlV9JIqYLgos03YorAueTIeOUskLJSEsfwCByjbu98ctXitUN3znXKp0bYD/WHSudCeA==",
       "dev": true,
       "license": "MIT",
@@ -5359,14 +5359,14 @@
     },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
-      "resolved": "https://npm.sinequa.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
       "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
       "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/abbrev": {
       "version": "4.0.0",
-      "resolved": "https://npm.sinequa.com/abbrev/-/abbrev-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
       "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
       "dev": true,
       "license": "ISC",
@@ -5376,7 +5376,7 @@
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
-      "resolved": "https://npm.sinequa.com/abort-controller/-/abort-controller-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
       "license": "MIT",
       "dependencies": {
@@ -5388,7 +5388,7 @@
     },
     "node_modules/accepts": {
       "version": "2.0.0",
-      "resolved": "https://npm.sinequa.com/accepts/-/accepts-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "dev": true,
       "license": "MIT",
@@ -5402,7 +5402,7 @@
     },
     "node_modules/agent-base": {
       "version": "7.1.3",
-      "resolved": "https://npm.sinequa.com/agent-base/-/agent-base-7.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
       "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
       "dev": true,
       "license": "MIT",
@@ -5412,7 +5412,7 @@
     },
     "node_modules/ajv": {
       "version": "8.18.0",
-      "resolved": "https://npm.sinequa.com/ajv/-/ajv-8.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
@@ -5429,7 +5429,7 @@
     },
     "node_modules/ajv-formats": {
       "version": "3.0.1",
-      "resolved": "https://npm.sinequa.com/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "dev": true,
       "license": "MIT",
@@ -5447,7 +5447,7 @@
     },
     "node_modules/algoliasearch": {
       "version": "5.35.0",
-      "resolved": "https://npm.sinequa.com/algoliasearch/-/algoliasearch-5.35.0.tgz",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.35.0.tgz",
       "integrity": "sha512-Y+moNhsqgLmvJdgTsO4GZNgsaDWv8AOGAaPeIeHKlDn/XunoAqYbA+XNpBd1dW8GOXAUDyxC9Rxc7AV4kpFcIg==",
       "dev": true,
       "license": "MIT",
@@ -5473,7 +5473,7 @@
     },
     "node_modules/ansi-regex": {
       "version": "6.1.0",
-      "resolved": "https://npm.sinequa.com/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
       "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
       "license": "MIT",
       "engines": {
@@ -5485,7 +5485,7 @@
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://npm.sinequa.com/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "license": "MIT",
       "dependencies": {
@@ -5500,7 +5500,7 @@
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
-      "resolved": "https://npm.sinequa.com/anymatch/-/anymatch-3.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "dev": true,
       "license": "ISC",
@@ -5514,7 +5514,7 @@
     },
     "node_modules/anymatch/node_modules/picomatch": {
       "version": "2.3.2",
-      "resolved": "https://npm.sinequa.com/picomatch/-/picomatch-2.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
@@ -5527,13 +5527,13 @@
     },
     "node_modules/argparse": {
       "version": "2.0.1",
-      "resolved": "https://npm.sinequa.com/argparse/-/argparse-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
     "node_modules/array-back": {
       "version": "3.1.0",
-      "resolved": "https://npm.sinequa.com/array-back/-/array-back-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
       "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
       "dev": true,
       "license": "MIT",
@@ -5543,7 +5543,7 @@
     },
     "node_modules/async-function": {
       "version": "1.0.0",
-      "resolved": "https://npm.sinequa.com/async-function/-/async-function-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
       "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
       "dev": true,
       "license": "MIT",
@@ -5553,7 +5553,7 @@
     },
     "node_modules/async-generator-function": {
       "version": "1.0.0",
-      "resolved": "https://npm.sinequa.com/async-generator-function/-/async-generator-function-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/async-generator-function/-/async-generator-function-1.0.0.tgz",
       "integrity": "sha512-+NAXNqgCrB95ya4Sr66i1CL2hqLVckAk7xwRYWdcm39/ELQ6YNn1aw5r0bdQtqNZgQpEWzc5yc/igXc7aL5SLA==",
       "dev": true,
       "license": "MIT",
@@ -5563,7 +5563,7 @@
     },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
-      "resolved": "https://npm.sinequa.com/autoprefixer/-/autoprefixer-10.4.21.tgz",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
       "integrity": "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==",
       "dev": true,
       "funding": [
@@ -5601,13 +5601,13 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://npm.sinequa.com/balanced-match/-/balanced-match-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
-      "resolved": "https://npm.sinequa.com/base64-js/-/base64-js-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "funding": [
         {
@@ -5627,7 +5627,7 @@
     },
     "node_modules/beasties": {
       "version": "0.3.5",
-      "resolved": "https://npm.sinequa.com/beasties/-/beasties-0.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/beasties/-/beasties-0.3.5.tgz",
       "integrity": "sha512-NaWu+f4YrJxEttJSm16AzMIFtVldCvaJ68b1L098KpqXmxt9xOLtKoLkKxb8ekhOrLqEJAbvT6n6SEvB/sac7A==",
       "dev": true,
       "license": "Apache-2.0",
@@ -5647,7 +5647,7 @@
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
-      "resolved": "https://npm.sinequa.com/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
       "dev": true,
       "license": "MIT",
@@ -5660,7 +5660,7 @@
     },
     "node_modules/bl": {
       "version": "4.1.0",
-      "resolved": "https://npm.sinequa.com/bl/-/bl-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
       "license": "MIT",
       "dependencies": {
@@ -5671,7 +5671,7 @@
     },
     "node_modules/body-parser": {
       "version": "2.2.2",
-      "resolved": "https://npm.sinequa.com/body-parser/-/body-parser-2.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
       "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
       "dev": true,
       "license": "MIT",
@@ -5696,14 +5696,14 @@
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
-      "resolved": "https://npm.sinequa.com/boolbase/-/boolbase-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
       "version": "2.0.3",
-      "resolved": "https://npm.sinequa.com/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
       "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "license": "MIT",
       "dependencies": {
@@ -5712,7 +5712,7 @@
     },
     "node_modules/braces": {
       "version": "3.0.3",
-      "resolved": "https://npm.sinequa.com/braces/-/braces-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "license": "MIT",
@@ -5725,7 +5725,7 @@
     },
     "node_modules/browserslist": {
       "version": "4.25.0",
-      "resolved": "https://npm.sinequa.com/browserslist/-/browserslist-4.25.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.0.tgz",
       "integrity": "sha512-PJ8gYKeS5e/whHBh8xrwYK+dAvEj7JXtz6uTucnMRB8OiGTsKccFekoRrjajPBHV8oOY+2tI4uxeceSimKwMFA==",
       "dev": true,
       "funding": [
@@ -5758,7 +5758,7 @@
     },
     "node_modules/buffer": {
       "version": "5.7.1",
-      "resolved": "https://npm.sinequa.com/buffer/-/buffer-5.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "funding": [
         {
@@ -5782,14 +5782,14 @@
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
-      "resolved": "https://npm.sinequa.com/buffer-from/-/buffer-from-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
-      "resolved": "https://npm.sinequa.com/bytes/-/bytes-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "dev": true,
       "license": "MIT",
@@ -5799,7 +5799,7 @@
     },
     "node_modules/cacache": {
       "version": "20.0.3",
-      "resolved": "https://npm.sinequa.com/cacache/-/cacache-20.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.3.tgz",
       "integrity": "sha512-3pUp4e8hv07k1QlijZu6Kn7c9+ZpWWk4j3F8N3xPuCExULobqJydKYOTj1FTq58srkJsXvO7LbGAH4C0ZU3WGw==",
       "dev": true,
       "license": "ISC",
@@ -5822,7 +5822,7 @@
     },
     "node_modules/cacache/node_modules/balanced-match": {
       "version": "4.0.4",
-      "resolved": "https://npm.sinequa.com/balanced-match/-/balanced-match-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
       "license": "MIT",
@@ -5832,7 +5832,7 @@
     },
     "node_modules/cacache/node_modules/brace-expansion": {
       "version": "5.0.5",
-      "resolved": "https://npm.sinequa.com/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
       "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
@@ -5845,7 +5845,7 @@
     },
     "node_modules/cacache/node_modules/glob": {
       "version": "13.0.1",
-      "resolved": "https://npm.sinequa.com/glob/-/glob-13.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.1.tgz",
       "integrity": "sha512-B7U/vJpE3DkJ5WXTgTpTRN63uV42DseiXXKMwG14LQBXmsdeIoHAPbU/MEo6II0k5ED74uc2ZGTC6MwHFQhF6w==",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -5863,7 +5863,7 @@
     },
     "node_modules/cacache/node_modules/lru-cache": {
       "version": "11.2.5",
-      "resolved": "https://npm.sinequa.com/lru-cache/-/lru-cache-11.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
       "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -5873,7 +5873,7 @@
     },
     "node_modules/cacache/node_modules/minimatch": {
       "version": "10.2.4",
-      "resolved": "https://npm.sinequa.com/minimatch/-/minimatch-10.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
       "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -5889,7 +5889,7 @@
     },
     "node_modules/cacache/node_modules/path-scurry": {
       "version": "2.0.1",
-      "resolved": "https://npm.sinequa.com/path-scurry/-/path-scurry-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
       "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -5906,7 +5906,7 @@
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
-      "resolved": "https://npm.sinequa.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "dev": true,
       "license": "MIT",
@@ -5920,7 +5920,7 @@
     },
     "node_modules/call-bound": {
       "version": "1.0.4",
-      "resolved": "https://npm.sinequa.com/call-bound/-/call-bound-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "dev": true,
       "license": "MIT",
@@ -5937,7 +5937,7 @@
     },
     "node_modules/callsites": {
       "version": "3.1.0",
-      "resolved": "https://npm.sinequa.com/callsites/-/callsites-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "license": "MIT",
       "engines": {
@@ -5946,7 +5946,7 @@
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001723",
-      "resolved": "https://npm.sinequa.com/caniuse-lite/-/caniuse-lite-1.0.30001723.tgz",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001723.tgz",
       "integrity": "sha512-1R/elMjtehrFejxwmexeXAtae5UO9iSyFn6G/I806CYC/BLyyBk1EPhrKBkWhy6wM6Xnm47dSJQec+tLJ39WHw==",
       "dev": true,
       "funding": [
@@ -5967,7 +5967,7 @@
     },
     "node_modules/chalk": {
       "version": "4.1.2",
-      "resolved": "https://npm.sinequa.com/chalk/-/chalk-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "license": "MIT",
       "dependencies": {
@@ -5983,14 +5983,14 @@
     },
     "node_modules/chardet": {
       "version": "2.1.1",
-      "resolved": "https://npm.sinequa.com/chardet/-/chardet-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
       "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/chart.js": {
       "version": "4.5.0",
-      "resolved": "https://npm.sinequa.com/chart.js/-/chart.js-4.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
       "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
       "license": "MIT",
       "dependencies": {
@@ -6002,7 +6002,7 @@
     },
     "node_modules/chokidar": {
       "version": "4.0.3",
-      "resolved": "https://npm.sinequa.com/chokidar/-/chokidar-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
@@ -6018,7 +6018,7 @@
     },
     "node_modules/chownr": {
       "version": "3.0.0",
-      "resolved": "https://npm.sinequa.com/chownr/-/chownr-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
       "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -6027,7 +6027,7 @@
     },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
-      "resolved": "https://npm.sinequa.com/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
       "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6039,7 +6039,7 @@
     },
     "node_modules/class-variance-authority/node_modules/clsx": {
       "version": "2.1.1",
-      "resolved": "https://npm.sinequa.com/clsx/-/clsx-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "license": "MIT",
       "engines": {
@@ -6048,7 +6048,7 @@
     },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
-      "resolved": "https://npm.sinequa.com/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
       "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
       "dev": true,
       "license": "MIT",
@@ -6064,7 +6064,7 @@
     },
     "node_modules/cli-spinners": {
       "version": "2.9.2",
-      "resolved": "https://npm.sinequa.com/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
       "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
       "license": "MIT",
       "engines": {
@@ -6076,7 +6076,7 @@
     },
     "node_modules/cli-truncate": {
       "version": "4.0.0",
-      "resolved": "https://npm.sinequa.com/cli-truncate/-/cli-truncate-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
       "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
       "dev": true,
       "license": "MIT",
@@ -6093,14 +6093,14 @@
     },
     "node_modules/cli-truncate/node_modules/emoji-regex": {
       "version": "10.4.0",
-      "resolved": "https://npm.sinequa.com/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
       "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/cli-truncate/node_modules/string-width": {
       "version": "7.2.0",
-      "resolved": "https://npm.sinequa.com/string-width/-/string-width-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "dev": true,
       "license": "MIT",
@@ -6118,7 +6118,7 @@
     },
     "node_modules/cli-width": {
       "version": "4.1.0",
-      "resolved": "https://npm.sinequa.com/cli-width/-/cli-width-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
       "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
       "dev": true,
       "license": "ISC",
@@ -6128,7 +6128,7 @@
     },
     "node_modules/cliui": {
       "version": "8.0.1",
-      "resolved": "https://npm.sinequa.com/cliui/-/cliui-8.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "license": "ISC",
       "dependencies": {
@@ -6142,7 +6142,7 @@
     },
     "node_modules/cliui/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://npm.sinequa.com/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
       "engines": {
@@ -6151,13 +6151,13 @@
     },
     "node_modules/cliui/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://npm.sinequa.com/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
     },
     "node_modules/cliui/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://npm.sinequa.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "license": "MIT",
       "engines": {
@@ -6166,7 +6166,7 @@
     },
     "node_modules/cliui/node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://npm.sinequa.com/string-width/-/string-width-4.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "license": "MIT",
       "dependencies": {
@@ -6180,7 +6180,7 @@
     },
     "node_modules/cliui/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://npm.sinequa.com/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
       "dependencies": {
@@ -6192,7 +6192,7 @@
     },
     "node_modules/cliui/node_modules/wrap-ansi": {
       "version": "7.0.0",
-      "resolved": "https://npm.sinequa.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "license": "MIT",
       "dependencies": {
@@ -6209,7 +6209,7 @@
     },
     "node_modules/clone": {
       "version": "1.0.4",
-      "resolved": "https://npm.sinequa.com/clone/-/clone-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
       "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
       "license": "MIT",
       "engines": {
@@ -6218,7 +6218,7 @@
     },
     "node_modules/clsx": {
       "version": "2.1.0",
-      "resolved": "https://npm.sinequa.com/clsx/-/clsx-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
       "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
       "license": "MIT",
       "engines": {
@@ -6227,7 +6227,7 @@
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://npm.sinequa.com/color-convert/-/color-convert-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "license": "MIT",
       "dependencies": {
@@ -6239,20 +6239,20 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://npm.sinequa.com/color-name/-/color-name-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
     "node_modules/colorette": {
       "version": "2.0.20",
-      "resolved": "https://npm.sinequa.com/colorette/-/colorette-2.0.20.tgz",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/command-line-args": {
       "version": "5.2.1",
-      "resolved": "https://npm.sinequa.com/command-line-args/-/command-line-args-5.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
       "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
       "dev": true,
       "license": "MIT",
@@ -6268,7 +6268,7 @@
     },
     "node_modules/commander": {
       "version": "13.1.0",
-      "resolved": "https://npm.sinequa.com/commander/-/commander-13.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
       "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
       "dev": true,
       "license": "MIT",
@@ -6278,7 +6278,7 @@
     },
     "node_modules/content-disposition": {
       "version": "1.0.1",
-      "resolved": "https://npm.sinequa.com/content-disposition/-/content-disposition-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
       "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
       "dev": true,
       "license": "MIT",
@@ -6292,7 +6292,7 @@
     },
     "node_modules/content-type": {
       "version": "1.0.5",
-      "resolved": "https://npm.sinequa.com/content-type/-/content-type-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "dev": true,
       "license": "MIT",
@@ -6302,14 +6302,14 @@
     },
     "node_modules/convert-source-map": {
       "version": "1.9.0",
-      "resolved": "https://npm.sinequa.com/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "0.7.2",
-      "resolved": "https://npm.sinequa.com/cookie/-/cookie-0.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "dev": true,
       "license": "MIT",
@@ -6319,7 +6319,7 @@
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",
-      "resolved": "https://npm.sinequa.com/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
       "dev": true,
       "license": "MIT",
@@ -6329,7 +6329,7 @@
     },
     "node_modules/cors": {
       "version": "2.8.5",
-      "resolved": "https://npm.sinequa.com/cors/-/cors-2.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
       "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
       "dev": true,
       "license": "MIT",
@@ -6343,7 +6343,7 @@
     },
     "node_modules/cosmiconfig": {
       "version": "8.3.6",
-      "resolved": "https://npm.sinequa.com/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
       "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
       "license": "MIT",
       "dependencies": {
@@ -6369,7 +6369,7 @@
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
-      "resolved": "https://npm.sinequa.com/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "license": "MIT",
       "dependencies": {
@@ -6383,7 +6383,7 @@
     },
     "node_modules/css-select": {
       "version": "6.0.0",
-      "resolved": "https://npm.sinequa.com/css-select/-/css-select-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-6.0.0.tgz",
       "integrity": "sha512-rZZVSLle8v0+EY8QAkDWrKhpgt6SA5OtHsgBnsj6ZaLb5dmDVOWUDtQitd9ydxxvEjhewNudS6eTVU7uOyzvXw==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -6400,7 +6400,7 @@
     },
     "node_modules/css-what": {
       "version": "7.0.0",
-      "resolved": "https://npm.sinequa.com/css-what/-/css-what-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-7.0.0.tgz",
       "integrity": "sha512-wD5oz5xibMOPHzy13CyGmogB3phdvcDaB5t0W/Nr5Z2O/agcB8YwOz6e2Lsp10pNDzBoDO9nVa3RGs/2BttpHQ==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -6413,7 +6413,7 @@
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
-      "resolved": "https://npm.sinequa.com/cssesc/-/cssesc-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "dev": true,
       "license": "MIT",
@@ -6426,7 +6426,7 @@
     },
     "node_modules/date-fns": {
       "version": "2.30.0",
-      "resolved": "https://npm.sinequa.com/date-fns/-/date-fns-2.30.0.tgz",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
       "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
       "license": "MIT",
       "dependencies": {
@@ -6442,7 +6442,7 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://npm.sinequa.com/debug/-/debug-4.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
@@ -6460,7 +6460,7 @@
     },
     "node_modules/defaults": {
       "version": "1.0.4",
-      "resolved": "https://npm.sinequa.com/defaults/-/defaults-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
       "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
       "license": "MIT",
       "dependencies": {
@@ -6472,7 +6472,7 @@
     },
     "node_modules/depd": {
       "version": "2.0.0",
-      "resolved": "https://npm.sinequa.com/depd/-/depd-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "dev": true,
       "license": "MIT",
@@ -6482,7 +6482,7 @@
     },
     "node_modules/detect-libc": {
       "version": "2.0.4",
-      "resolved": "https://npm.sinequa.com/detect-libc/-/detect-libc-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
       "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
       "license": "Apache-2.0",
       "engines": {
@@ -6491,7 +6491,7 @@
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
-      "resolved": "https://npm.sinequa.com/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
       "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
       "dev": true,
       "license": "MIT",
@@ -6506,7 +6506,7 @@
     },
     "node_modules/domelementtype": {
       "version": "2.3.0",
-      "resolved": "https://npm.sinequa.com/domelementtype/-/domelementtype-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
       "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
       "dev": true,
       "funding": [
@@ -6519,7 +6519,7 @@
     },
     "node_modules/domhandler": {
       "version": "5.0.3",
-      "resolved": "https://npm.sinequa.com/domhandler/-/domhandler-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
       "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -6535,7 +6535,7 @@
     },
     "node_modules/domutils": {
       "version": "3.2.2",
-      "resolved": "https://npm.sinequa.com/domutils/-/domutils-3.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
       "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -6550,7 +6550,7 @@
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
-      "resolved": "https://npm.sinequa.com/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "dev": true,
       "license": "MIT",
@@ -6565,33 +6565,33 @@
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
-      "resolved": "https://npm.sinequa.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "license": "MIT"
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
-      "resolved": "https://npm.sinequa.com/ee-first/-/ee-first-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.170",
-      "resolved": "https://npm.sinequa.com/electron-to-chromium/-/electron-to-chromium-1.5.170.tgz",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.170.tgz",
       "integrity": "sha512-GP+M7aeluQo9uAyiTCxgIj/j+PrWhMlY7LFVj8prlsPljd0Fdg9AprlfUi+OCSFWy9Y5/2D/Jrj9HS8Z4rpKWA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
-      "resolved": "https://npm.sinequa.com/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
-      "resolved": "https://npm.sinequa.com/encodeurl/-/encodeurl-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "dev": true,
       "license": "MIT",
@@ -6601,7 +6601,7 @@
     },
     "node_modules/encoding": {
       "version": "0.1.13",
-      "resolved": "https://npm.sinequa.com/encoding/-/encoding-0.1.13.tgz",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
       "dev": true,
       "license": "MIT",
@@ -6612,7 +6612,7 @@
     },
     "node_modules/encoding/node_modules/iconv-lite": {
       "version": "0.6.3",
-      "resolved": "https://npm.sinequa.com/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "dev": true,
       "license": "MIT",
@@ -6626,7 +6626,7 @@
     },
     "node_modules/enhanced-resolve": {
       "version": "5.18.1",
-      "resolved": "https://npm.sinequa.com/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
       "integrity": "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==",
       "license": "MIT",
       "dependencies": {
@@ -6639,7 +6639,7 @@
     },
     "node_modules/entities": {
       "version": "4.5.0",
-      "resolved": "https://npm.sinequa.com/entities/-/entities-4.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "license": "BSD-2-Clause",
       "engines": {
@@ -6651,7 +6651,7 @@
     },
     "node_modules/env-paths": {
       "version": "2.2.1",
-      "resolved": "https://npm.sinequa.com/env-paths/-/env-paths-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
       "dev": true,
       "license": "MIT",
@@ -6661,7 +6661,7 @@
     },
     "node_modules/environment": {
       "version": "1.1.0",
-      "resolved": "https://npm.sinequa.com/environment/-/environment-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
       "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
       "dev": true,
       "license": "MIT",
@@ -6674,14 +6674,14 @@
     },
     "node_modules/err-code": {
       "version": "2.0.3",
-      "resolved": "https://npm.sinequa.com/err-code/-/err-code-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
       "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
-      "resolved": "https://npm.sinequa.com/error-ex/-/error-ex-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "license": "MIT",
       "dependencies": {
@@ -6690,7 +6690,7 @@
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
-      "resolved": "https://npm.sinequa.com/es-define-property/-/es-define-property-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "dev": true,
       "license": "MIT",
@@ -6700,7 +6700,7 @@
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
-      "resolved": "https://npm.sinequa.com/es-errors/-/es-errors-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "dev": true,
       "license": "MIT",
@@ -6710,7 +6710,7 @@
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
-      "resolved": "https://npm.sinequa.com/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "dev": true,
       "license": "MIT",
@@ -6723,7 +6723,7 @@
     },
     "node_modules/esbuild": {
       "version": "0.25.9",
-      "resolved": "https://npm.sinequa.com/esbuild/-/esbuild-0.25.9.tgz",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.9.tgz",
       "integrity": "sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==",
       "dev": true,
       "hasInstallScript": true,
@@ -6765,7 +6765,7 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "resolved": "https://npm.sinequa.com/escalade/-/escalade-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "license": "MIT",
       "engines": {
@@ -6774,14 +6774,14 @@
     },
     "node_modules/escape-html": {
       "version": "1.0.3",
-      "resolved": "https://npm.sinequa.com/escape-html/-/escape-html-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/etag": {
       "version": "1.8.1",
-      "resolved": "https://npm.sinequa.com/etag/-/etag-1.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true,
       "license": "MIT",
@@ -6791,7 +6791,7 @@
     },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
-      "resolved": "https://npm.sinequa.com/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
       "license": "MIT",
       "engines": {
@@ -6800,14 +6800,14 @@
     },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
-      "resolved": "https://npm.sinequa.com/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/eventsource": {
       "version": "2.0.2",
-      "resolved": "https://npm.sinequa.com/eventsource/-/eventsource-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
       "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
       "license": "MIT",
       "engines": {
@@ -6816,7 +6816,7 @@
     },
     "node_modules/eventsource-parser": {
       "version": "3.0.6",
-      "resolved": "https://npm.sinequa.com/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
       "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
       "dev": true,
       "license": "MIT",
@@ -6826,7 +6826,7 @@
     },
     "node_modules/execa": {
       "version": "8.0.1",
-      "resolved": "https://npm.sinequa.com/execa/-/execa-8.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
       "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
       "dev": true,
       "license": "MIT",
@@ -6850,14 +6850,14 @@
     },
     "node_modules/exponential-backoff": {
       "version": "3.1.3",
-      "resolved": "https://npm.sinequa.com/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
       "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/express": {
       "version": "5.2.1",
-      "resolved": "https://npm.sinequa.com/express/-/express-5.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "dev": true,
       "license": "MIT",
@@ -6901,7 +6901,7 @@
     },
     "node_modules/express-rate-limit": {
       "version": "8.3.1",
-      "resolved": "https://npm.sinequa.com/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
       "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
       "dev": true,
       "license": "MIT",
@@ -6920,14 +6920,14 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://npm.sinequa.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-uri": {
       "version": "3.0.6",
-      "resolved": "https://npm.sinequa.com/fast-uri/-/fast-uri-3.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
       "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
       "dev": true,
       "funding": [
@@ -6944,7 +6944,7 @@
     },
     "node_modules/fdir": {
       "version": "6.5.0",
-      "resolved": "https://npm.sinequa.com/fdir/-/fdir-6.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
@@ -6962,7 +6962,7 @@
     },
     "node_modules/fetch-cookie": {
       "version": "2.2.0",
-      "resolved": "https://npm.sinequa.com/fetch-cookie/-/fetch-cookie-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/fetch-cookie/-/fetch-cookie-2.2.0.tgz",
       "integrity": "sha512-h9AgfjURuCgA2+2ISl8GbavpUdR+WGAM2McW/ovn4tVccegp8ZqCKWSBR8uRdM8dDNlx5WdKRWxBYUwteLDCNQ==",
       "license": "Unlicense",
       "dependencies": {
@@ -6972,7 +6972,7 @@
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
-      "resolved": "https://npm.sinequa.com/fill-range/-/fill-range-7.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "license": "MIT",
@@ -6985,7 +6985,7 @@
     },
     "node_modules/finalhandler": {
       "version": "2.1.1",
-      "resolved": "https://npm.sinequa.com/finalhandler/-/finalhandler-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
       "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "dev": true,
       "license": "MIT",
@@ -7007,7 +7007,7 @@
     },
     "node_modules/find-replace": {
       "version": "3.0.0",
-      "resolved": "https://npm.sinequa.com/find-replace/-/find-replace-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
       "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
       "dev": true,
       "license": "MIT",
@@ -7020,7 +7020,7 @@
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
-      "resolved": "https://npm.sinequa.com/foreground-child/-/foreground-child-3.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
       "license": "ISC",
       "dependencies": {
@@ -7036,7 +7036,7 @@
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
-      "resolved": "https://npm.sinequa.com/forwarded/-/forwarded-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "dev": true,
       "license": "MIT",
@@ -7046,7 +7046,7 @@
     },
     "node_modules/fraction.js": {
       "version": "4.3.7",
-      "resolved": "https://npm.sinequa.com/fraction.js/-/fraction.js-4.3.7.tgz",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
       "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
       "dev": true,
       "license": "MIT",
@@ -7060,7 +7060,7 @@
     },
     "node_modules/fresh": {
       "version": "2.0.0",
-      "resolved": "https://npm.sinequa.com/fresh/-/fresh-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "dev": true,
       "license": "MIT",
@@ -7070,7 +7070,7 @@
     },
     "node_modules/fs-extra": {
       "version": "11.3.0",
-      "resolved": "https://npm.sinequa.com/fs-extra/-/fs-extra-11.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
       "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
       "license": "MIT",
       "dependencies": {
@@ -7084,7 +7084,7 @@
     },
     "node_modules/fs-minipass": {
       "version": "3.0.3",
-      "resolved": "https://npm.sinequa.com/fs-minipass/-/fs-minipass-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
       "integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
       "dev": true,
       "license": "ISC",
@@ -7097,13 +7097,13 @@
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://npm.sinequa.com/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
-      "resolved": "https://npm.sinequa.com/fsevents/-/fsevents-2.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
@@ -7118,7 +7118,7 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
-      "resolved": "https://npm.sinequa.com/function-bind/-/function-bind-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "dev": true,
       "license": "MIT",
@@ -7128,7 +7128,7 @@
     },
     "node_modules/generator-function": {
       "version": "2.0.1",
-      "resolved": "https://npm.sinequa.com/generator-function/-/generator-function-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
       "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
       "dev": true,
       "license": "MIT",
@@ -7138,7 +7138,7 @@
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
-      "resolved": "https://npm.sinequa.com/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true,
       "license": "MIT",
@@ -7148,7 +7148,7 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "resolved": "https://npm.sinequa.com/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "license": "ISC",
       "engines": {
@@ -7157,7 +7157,7 @@
     },
     "node_modules/get-east-asian-width": {
       "version": "1.3.0",
-      "resolved": "https://npm.sinequa.com/get-east-asian-width/-/get-east-asian-width-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.3.0.tgz",
       "integrity": "sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==",
       "dev": true,
       "license": "MIT",
@@ -7170,7 +7170,7 @@
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.1",
-      "resolved": "https://npm.sinequa.com/get-intrinsic/-/get-intrinsic-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.1.tgz",
       "integrity": "sha512-fk1ZVEeOX9hVZ6QzoBNEC55+Ucqg4sTVwrVuigZhuRPESVFpMyXnd3sbXvPOwp7Y9riVyANiqhEuRF0G1aVSeQ==",
       "dev": true,
       "license": "MIT",
@@ -7198,7 +7198,7 @@
     },
     "node_modules/get-proto": {
       "version": "1.0.1",
-      "resolved": "https://npm.sinequa.com/get-proto/-/get-proto-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "dev": true,
       "license": "MIT",
@@ -7212,7 +7212,7 @@
     },
     "node_modules/get-stream": {
       "version": "8.0.1",
-      "resolved": "https://npm.sinequa.com/get-stream/-/get-stream-8.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
       "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
       "dev": true,
       "license": "MIT",
@@ -7225,7 +7225,7 @@
     },
     "node_modules/glob": {
       "version": "10.5.0",
-      "resolved": "https://npm.sinequa.com/glob/-/glob-10.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
       "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "license": "ISC",
       "dependencies": {
@@ -7245,7 +7245,7 @@
     },
     "node_modules/glob-parent": {
       "version": "5.1.2",
-      "resolved": "https://npm.sinequa.com/glob-parent/-/glob-parent-5.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "license": "ISC",
@@ -7258,14 +7258,14 @@
     },
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
-      "resolved": "https://npm.sinequa.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/gopd": {
       "version": "1.2.0",
-      "resolved": "https://npm.sinequa.com/gopd/-/gopd-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "dev": true,
       "license": "MIT",
@@ -7278,13 +7278,13 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "resolved": "https://npm.sinequa.com/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://npm.sinequa.com/has-flag/-/has-flag-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "license": "MIT",
       "engines": {
@@ -7293,7 +7293,7 @@
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
-      "resolved": "https://npm.sinequa.com/has-symbols/-/has-symbols-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "dev": true,
       "license": "MIT",
@@ -7306,7 +7306,7 @@
     },
     "node_modules/hasown": {
       "version": "2.0.2",
-      "resolved": "https://npm.sinequa.com/hasown/-/hasown-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
       "dev": true,
       "license": "MIT",
@@ -7319,7 +7319,7 @@
     },
     "node_modules/highlight-words": {
       "version": "1.2.2",
-      "resolved": "https://npm.sinequa.com/highlight-words/-/highlight-words-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/highlight-words/-/highlight-words-1.2.2.tgz",
       "integrity": "sha512-Mf4xfPXYm8Ay1wTibCrHpNWeR2nUMynMVFkXCi4mbl+TEgmNOe+I4hV7W3OCZcSvzGL6kupaqpfHOemliMTGxQ==",
       "license": "MIT",
       "engines": {
@@ -7329,7 +7329,7 @@
     },
     "node_modules/hono": {
       "version": "4.12.15",
-      "resolved": "https://npm.sinequa.com/hono/-/hono-4.12.15.tgz",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
       "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
       "dev": true,
       "license": "MIT",
@@ -7339,7 +7339,7 @@
     },
     "node_modules/hosted-git-info": {
       "version": "9.0.2",
-      "resolved": "https://npm.sinequa.com/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
       "integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
       "dev": true,
       "license": "ISC",
@@ -7352,7 +7352,7 @@
     },
     "node_modules/hosted-git-info/node_modules/lru-cache": {
       "version": "11.2.5",
-      "resolved": "https://npm.sinequa.com/lru-cache/-/lru-cache-11.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
       "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -7362,7 +7362,7 @@
     },
     "node_modules/htmlparser2": {
       "version": "10.0.0",
-      "resolved": "https://npm.sinequa.com/htmlparser2/-/htmlparser2-10.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
       "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
       "dev": true,
       "funding": [
@@ -7382,7 +7382,7 @@
     },
     "node_modules/htmlparser2/node_modules/entities": {
       "version": "6.0.1",
-      "resolved": "https://npm.sinequa.com/entities/-/entities-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -7395,14 +7395,14 @@
     },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
-      "resolved": "https://npm.sinequa.com/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
-      "resolved": "https://npm.sinequa.com/http-errors/-/http-errors-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "dev": true,
       "license": "MIT",
@@ -7423,7 +7423,7 @@
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
-      "resolved": "https://npm.sinequa.com/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "dev": true,
       "license": "MIT",
@@ -7437,7 +7437,7 @@
     },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
-      "resolved": "https://npm.sinequa.com/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dev": true,
       "license": "MIT",
@@ -7451,7 +7451,7 @@
     },
     "node_modules/human-signals": {
       "version": "5.0.0",
-      "resolved": "https://npm.sinequa.com/human-signals/-/human-signals-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
       "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -7461,7 +7461,7 @@
     },
     "node_modules/husky": {
       "version": "9.1.7",
-      "resolved": "https://npm.sinequa.com/husky/-/husky-9.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
       "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
       "dev": true,
       "license": "MIT",
@@ -7477,7 +7477,7 @@
     },
     "node_modules/iconv-lite": {
       "version": "0.7.0",
-      "resolved": "https://npm.sinequa.com/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
       "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
       "dev": true,
       "license": "MIT",
@@ -7494,7 +7494,7 @@
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
-      "resolved": "https://npm.sinequa.com/ieee754/-/ieee754-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
       "funding": [
         {
@@ -7514,7 +7514,7 @@
     },
     "node_modules/ignore-walk": {
       "version": "8.0.0",
-      "resolved": "https://npm.sinequa.com/ignore-walk/-/ignore-walk-8.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-8.0.0.tgz",
       "integrity": "sha512-FCeMZT4NiRQGh+YkeKMtWrOmBgWjHjMJ26WQWrRQyoyzqevdaGSakUaJW5xQYmjLlUVk2qUnCjYVBax9EKKg8A==",
       "dev": true,
       "license": "ISC",
@@ -7527,7 +7527,7 @@
     },
     "node_modules/ignore-walk/node_modules/balanced-match": {
       "version": "4.0.4",
-      "resolved": "https://npm.sinequa.com/balanced-match/-/balanced-match-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
       "license": "MIT",
@@ -7537,7 +7537,7 @@
     },
     "node_modules/ignore-walk/node_modules/brace-expansion": {
       "version": "5.0.5",
-      "resolved": "https://npm.sinequa.com/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
       "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
@@ -7550,7 +7550,7 @@
     },
     "node_modules/ignore-walk/node_modules/minimatch": {
       "version": "10.2.4",
-      "resolved": "https://npm.sinequa.com/minimatch/-/minimatch-10.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
       "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -7566,14 +7566,14 @@
     },
     "node_modules/immutable": {
       "version": "5.1.5",
-      "resolved": "https://npm.sinequa.com/immutable/-/immutable-5.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
       "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
-      "resolved": "https://npm.sinequa.com/import-fresh/-/import-fresh-3.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
       "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "license": "MIT",
       "dependencies": {
@@ -7589,7 +7589,7 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://npm.sinequa.com/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true,
       "license": "MIT",
@@ -7599,7 +7599,7 @@
     },
     "node_modules/inflight": {
       "version": "1.0.6",
-      "resolved": "https://npm.sinequa.com/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "license": "ISC",
       "dependencies": {
@@ -7609,13 +7609,13 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "resolved": "https://npm.sinequa.com/inherits/-/inherits-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
     "node_modules/ini": {
       "version": "5.0.0",
-      "resolved": "https://npm.sinequa.com/ini/-/ini-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-5.0.0.tgz",
       "integrity": "sha512-+N0ngpO3e7cRUWOJAS7qw0IZIVc6XPrW4MlFBdD066F2L4k1L6ker3hLqSq7iXxU5tgS4WGkIUElWn5vogAEnw==",
       "dev": true,
       "license": "ISC",
@@ -7625,7 +7625,7 @@
     },
     "node_modules/ip-address": {
       "version": "10.1.0",
-      "resolved": "https://npm.sinequa.com/ip-address/-/ip-address-10.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
       "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
       "dev": true,
       "license": "MIT",
@@ -7635,7 +7635,7 @@
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
-      "resolved": "https://npm.sinequa.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "dev": true,
       "license": "MIT",
@@ -7645,13 +7645,13 @@
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://npm.sinequa.com/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "license": "MIT"
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
-      "resolved": "https://npm.sinequa.com/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "dev": true,
       "license": "MIT",
@@ -7664,7 +7664,7 @@
     },
     "node_modules/is-core-module": {
       "version": "2.16.1",
-      "resolved": "https://npm.sinequa.com/is-core-module/-/is-core-module-2.16.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
       "dev": true,
       "license": "MIT",
@@ -7680,7 +7680,7 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://npm.sinequa.com/is-extglob/-/is-extglob-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true,
       "license": "MIT",
@@ -7690,7 +7690,7 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "4.0.0",
-      "resolved": "https://npm.sinequa.com/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
       "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
       "dev": true,
       "license": "MIT",
@@ -7703,7 +7703,7 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "resolved": "https://npm.sinequa.com/is-glob/-/is-glob-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "license": "MIT",
@@ -7716,7 +7716,7 @@
     },
     "node_modules/is-interactive": {
       "version": "1.0.0",
-      "resolved": "https://npm.sinequa.com/is-interactive/-/is-interactive-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
       "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
       "license": "MIT",
       "engines": {
@@ -7725,7 +7725,7 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
-      "resolved": "https://npm.sinequa.com/is-number/-/is-number-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
       "license": "MIT",
@@ -7735,14 +7735,14 @@
     },
     "node_modules/is-promise": {
       "version": "4.0.0",
-      "resolved": "https://npm.sinequa.com/is-promise/-/is-promise-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/is-stream": {
       "version": "3.0.0",
-      "resolved": "https://npm.sinequa.com/is-stream/-/is-stream-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
       "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
       "dev": true,
       "license": "MIT",
@@ -7755,7 +7755,7 @@
     },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
-      "resolved": "https://npm.sinequa.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "license": "MIT",
       "engines": {
@@ -7767,13 +7767,13 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://npm.sinequa.com/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
-      "resolved": "https://npm.sinequa.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
       "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -7783,7 +7783,7 @@
     },
     "node_modules/istanbul-lib-instrument": {
       "version": "6.0.3",
-      "resolved": "https://npm.sinequa.com/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
       "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -7800,7 +7800,7 @@
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
-      "resolved": "https://npm.sinequa.com/jackspeak/-/jackspeak-3.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -7815,7 +7815,7 @@
     },
     "node_modules/jiti": {
       "version": "2.4.2",
-      "resolved": "https://npm.sinequa.com/jiti/-/jiti-2.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
       "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
       "license": "MIT",
       "bin": {
@@ -7824,7 +7824,7 @@
     },
     "node_modules/jose": {
       "version": "6.1.3",
-      "resolved": "https://npm.sinequa.com/jose/-/jose-6.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
       "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
       "dev": true,
       "license": "MIT",
@@ -7834,13 +7834,13 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://npm.sinequa.com/js-tokens/-/js-tokens-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
-      "resolved": "https://npm.sinequa.com/js-yaml/-/js-yaml-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "license": "MIT",
       "dependencies": {
@@ -7852,7 +7852,7 @@
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
-      "resolved": "https://npm.sinequa.com/jsesc/-/jsesc-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "dev": true,
       "license": "MIT",
@@ -7865,7 +7865,7 @@
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "5.0.0",
-      "resolved": "https://npm.sinequa.com/json-parse-even-better-errors/-/json-parse-even-better-errors-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-5.0.0.tgz",
       "integrity": "sha512-ZF1nxZ28VhQouRWhUcVlUIN3qwSgPuswK05s/HIaoetAoE/9tngVmCHjSxmSQPav1nd+lPtTL0YZ/2AFdR/iYQ==",
       "dev": true,
       "license": "MIT",
@@ -7875,21 +7875,21 @@
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "resolved": "https://npm.sinequa.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-typed": {
       "version": "8.0.2",
-      "resolved": "https://npm.sinequa.com/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/json5": {
       "version": "2.2.3",
-      "resolved": "https://npm.sinequa.com/json5/-/json5-2.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "license": "MIT",
@@ -7902,14 +7902,14 @@
     },
     "node_modules/jsonc-parser": {
       "version": "3.3.1",
-      "resolved": "https://npm.sinequa.com/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/jsonfile": {
       "version": "6.1.0",
-      "resolved": "https://npm.sinequa.com/jsonfile/-/jsonfile-6.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "license": "MIT",
       "dependencies": {
@@ -7921,7 +7921,7 @@
     },
     "node_modules/jsonparse": {
       "version": "1.3.1",
-      "resolved": "https://npm.sinequa.com/jsonparse/-/jsonparse-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true,
       "engines": [
@@ -7931,7 +7931,7 @@
     },
     "node_modules/keyux": {
       "version": "0.8.3",
-      "resolved": "https://npm.sinequa.com/keyux/-/keyux-0.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/keyux/-/keyux-0.8.3.tgz",
       "integrity": "sha512-eHut6xidU0Ts4o2pnuPZuCqYVV0tvzH3RYNfk2OICDj5wFWkskW1knlyn6fcBNFd/6/57URJ+XsR9HZ/FfYwjQ==",
       "funding": [
         {
@@ -7946,7 +7946,7 @@
     },
     "node_modules/lightningcss": {
       "version": "1.30.1",
-      "resolved": "https://npm.sinequa.com/lightningcss/-/lightningcss-1.30.1.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.1.tgz",
       "integrity": "sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==",
       "license": "MPL-2.0",
       "dependencies": {
@@ -7974,7 +7974,7 @@
     },
     "node_modules/lightningcss-android-arm64": {
       "version": "1.32.0",
-      "resolved": "https://npm.sinequa.com/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
       "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
       "cpu": [
         "arm64"
@@ -7995,7 +7995,7 @@
     },
     "node_modules/lightningcss-darwin-arm64": {
       "version": "1.30.1",
-      "resolved": "https://npm.sinequa.com/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.1.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.1.tgz",
       "integrity": "sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==",
       "cpu": [
         "arm64"
@@ -8015,7 +8015,7 @@
     },
     "node_modules/lightningcss-darwin-x64": {
       "version": "1.30.1",
-      "resolved": "https://npm.sinequa.com/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.1.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.1.tgz",
       "integrity": "sha512-k1EvjakfumAQoTfcXUcHQZhSpLlkAuEkdMBsI/ivWw9hL+7FtilQc0Cy3hrx0AAQrVtQAbMI7YjCgYgvn37PzA==",
       "cpu": [
         "x64"
@@ -8035,7 +8035,7 @@
     },
     "node_modules/lightningcss-freebsd-x64": {
       "version": "1.30.1",
-      "resolved": "https://npm.sinequa.com/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.1.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.1.tgz",
       "integrity": "sha512-kmW6UGCGg2PcyUE59K5r0kWfKPAVy4SltVeut+umLCFoJ53RdCUWxcRDzO1eTaxf/7Q2H7LTquFHPL5R+Gjyig==",
       "cpu": [
         "x64"
@@ -8055,7 +8055,7 @@
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
       "version": "1.30.1",
-      "resolved": "https://npm.sinequa.com/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.1.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.1.tgz",
       "integrity": "sha512-MjxUShl1v8pit+6D/zSPq9S9dQ2NPFSQwGvxBCYaBYLPlCWuPh9/t1MRS8iUaR8i+a6w7aps+B4N0S1TYP/R+Q==",
       "cpu": [
         "arm"
@@ -8075,7 +8075,7 @@
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
       "version": "1.30.1",
-      "resolved": "https://npm.sinequa.com/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.1.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.1.tgz",
       "integrity": "sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw==",
       "cpu": [
         "arm64"
@@ -8095,7 +8095,7 @@
     },
     "node_modules/lightningcss-linux-arm64-musl": {
       "version": "1.30.1",
-      "resolved": "https://npm.sinequa.com/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.1.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.1.tgz",
       "integrity": "sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==",
       "cpu": [
         "arm64"
@@ -8115,7 +8115,7 @@
     },
     "node_modules/lightningcss-linux-x64-gnu": {
       "version": "1.30.1",
-      "resolved": "https://npm.sinequa.com/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.1.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.1.tgz",
       "integrity": "sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==",
       "cpu": [
         "x64"
@@ -8135,7 +8135,7 @@
     },
     "node_modules/lightningcss-linux-x64-musl": {
       "version": "1.30.1",
-      "resolved": "https://npm.sinequa.com/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.1.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.1.tgz",
       "integrity": "sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==",
       "cpu": [
         "x64"
@@ -8155,7 +8155,7 @@
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
       "version": "1.30.1",
-      "resolved": "https://npm.sinequa.com/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.1.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.1.tgz",
       "integrity": "sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==",
       "cpu": [
         "arm64"
@@ -8175,7 +8175,7 @@
     },
     "node_modules/lightningcss-win32-x64-msvc": {
       "version": "1.30.1",
-      "resolved": "https://npm.sinequa.com/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.1.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.1.tgz",
       "integrity": "sha512-PVqXh48wh4T53F/1CCu8PIPCxLzWyCnn/9T5W1Jpmdy5h9Cwd+0YQS6/LwhHXSafuc61/xg9Lv5OrCby6a++jg==",
       "cpu": [
         "x64"
@@ -8195,7 +8195,7 @@
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
-      "resolved": "https://npm.sinequa.com/lilconfig/-/lilconfig-3.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
       "dev": true,
       "license": "MIT",
@@ -8208,13 +8208,13 @@
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
-      "resolved": "https://npm.sinequa.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
     "node_modules/linkify-it": {
       "version": "5.0.0",
-      "resolved": "https://npm.sinequa.com/linkify-it/-/linkify-it-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
       "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
       "license": "MIT",
       "dependencies": {
@@ -8223,7 +8223,7 @@
     },
     "node_modules/lint-staged": {
       "version": "15.5.2",
-      "resolved": "https://npm.sinequa.com/lint-staged/-/lint-staged-15.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.5.2.tgz",
       "integrity": "sha512-YUSOLq9VeRNAo/CTaVmhGDKG+LBtA8KF1X4K5+ykMSwWST1vDxJRB2kv2COgLb1fvpCo+A/y9A0G0znNVmdx4w==",
       "dev": true,
       "license": "MIT",
@@ -8251,7 +8251,7 @@
     },
     "node_modules/lint-staged/node_modules/chalk": {
       "version": "5.4.1",
-      "resolved": "https://npm.sinequa.com/chalk/-/chalk-5.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
       "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
       "dev": true,
       "license": "MIT",
@@ -8264,7 +8264,7 @@
     },
     "node_modules/listr2": {
       "version": "8.3.3",
-      "resolved": "https://npm.sinequa.com/listr2/-/listr2-8.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-8.3.3.tgz",
       "integrity": "sha512-LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ==",
       "dev": true,
       "license": "MIT",
@@ -8282,7 +8282,7 @@
     },
     "node_modules/listr2/node_modules/ansi-styles": {
       "version": "6.2.1",
-      "resolved": "https://npm.sinequa.com/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
       "dev": true,
       "license": "MIT",
@@ -8295,14 +8295,14 @@
     },
     "node_modules/listr2/node_modules/emoji-regex": {
       "version": "10.4.0",
-      "resolved": "https://npm.sinequa.com/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
       "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/listr2/node_modules/string-width": {
       "version": "7.2.0",
-      "resolved": "https://npm.sinequa.com/string-width/-/string-width-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "dev": true,
       "license": "MIT",
@@ -8320,7 +8320,7 @@
     },
     "node_modules/listr2/node_modules/wrap-ansi": {
       "version": "9.0.0",
-      "resolved": "https://npm.sinequa.com/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
       "integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
       "dev": true,
       "license": "MIT",
@@ -8338,7 +8338,7 @@
     },
     "node_modules/lmdb": {
       "version": "3.4.2",
-      "resolved": "https://npm.sinequa.com/lmdb/-/lmdb-3.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-3.4.2.tgz",
       "integrity": "sha512-nwVGUfTBUwJKXd6lRV8pFNfnrCC1+l49ESJRM19t/tFb/97QfJEixe5DYRvug5JO7DSFKoKaVy7oGMt5rVqZvg==",
       "dev": true,
       "hasInstallScript": true,
@@ -8366,47 +8366,47 @@
     },
     "node_modules/lodash": {
       "version": "4.18.1",
-      "resolved": "https://npm.sinequa.com/lodash/-/lodash-4.18.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
-      "resolved": "https://npm.sinequa.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.castarray": {
       "version": "4.4.0",
-      "resolved": "https://npm.sinequa.com/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
       "integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
-      "resolved": "https://npm.sinequa.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.kebabcase": {
       "version": "4.1.1",
-      "resolved": "https://npm.sinequa.com/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
       "integrity": "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
-      "resolved": "https://npm.sinequa.com/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
-      "resolved": "https://npm.sinequa.com/log-symbols/-/log-symbols-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
       "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
       "license": "MIT",
       "dependencies": {
@@ -8422,7 +8422,7 @@
     },
     "node_modules/log-update": {
       "version": "6.1.0",
-      "resolved": "https://npm.sinequa.com/log-update/-/log-update-6.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
       "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
       "dev": true,
       "license": "MIT",
@@ -8442,7 +8442,7 @@
     },
     "node_modules/log-update/node_modules/ansi-escapes": {
       "version": "7.0.0",
-      "resolved": "https://npm.sinequa.com/ansi-escapes/-/ansi-escapes-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.0.0.tgz",
       "integrity": "sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==",
       "dev": true,
       "license": "MIT",
@@ -8458,7 +8458,7 @@
     },
     "node_modules/log-update/node_modules/ansi-styles": {
       "version": "6.2.1",
-      "resolved": "https://npm.sinequa.com/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
       "dev": true,
       "license": "MIT",
@@ -8471,14 +8471,14 @@
     },
     "node_modules/log-update/node_modules/emoji-regex": {
       "version": "10.4.0",
-      "resolved": "https://npm.sinequa.com/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
       "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/log-update/node_modules/is-fullwidth-code-point": {
       "version": "5.0.0",
-      "resolved": "https://npm.sinequa.com/is-fullwidth-code-point/-/is-fullwidth-code-point-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.0.0.tgz",
       "integrity": "sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA==",
       "dev": true,
       "license": "MIT",
@@ -8494,7 +8494,7 @@
     },
     "node_modules/log-update/node_modules/slice-ansi": {
       "version": "7.1.0",
-      "resolved": "https://npm.sinequa.com/slice-ansi/-/slice-ansi-7.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.0.tgz",
       "integrity": "sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==",
       "dev": true,
       "license": "MIT",
@@ -8511,7 +8511,7 @@
     },
     "node_modules/log-update/node_modules/string-width": {
       "version": "7.2.0",
-      "resolved": "https://npm.sinequa.com/string-width/-/string-width-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "dev": true,
       "license": "MIT",
@@ -8529,7 +8529,7 @@
     },
     "node_modules/log-update/node_modules/wrap-ansi": {
       "version": "9.0.0",
-      "resolved": "https://npm.sinequa.com/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
       "integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
       "dev": true,
       "license": "MIT",
@@ -8547,7 +8547,7 @@
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
-      "resolved": "https://npm.sinequa.com/lru-cache/-/lru-cache-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
       "license": "ISC",
@@ -8557,7 +8557,7 @@
     },
     "node_modules/magic-string": {
       "version": "0.30.17",
-      "resolved": "https://npm.sinequa.com/magic-string/-/magic-string-0.30.17.tgz",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
       "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
       "license": "MIT",
       "dependencies": {
@@ -8566,7 +8566,7 @@
     },
     "node_modules/make-fetch-happen": {
       "version": "15.0.3",
-      "resolved": "https://npm.sinequa.com/make-fetch-happen/-/make-fetch-happen-15.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.3.tgz",
       "integrity": "sha512-iyyEpDty1mwW3dGlYXAJqC/azFn5PPvgKVwXayOGBSmKLxhKZ9fg4qIan2ePpp1vJIwfFiO34LAPZgq9SZW9Aw==",
       "dev": true,
       "license": "ISC",
@@ -8589,7 +8589,7 @@
     },
     "node_modules/make-fetch-happen/node_modules/proc-log": {
       "version": "6.1.0",
-      "resolved": "https://npm.sinequa.com/proc-log/-/proc-log-6.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
       "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
       "dev": true,
       "license": "ISC",
@@ -8599,13 +8599,13 @@
     },
     "node_modules/make-plural": {
       "version": "7.4.0",
-      "resolved": "https://npm.sinequa.com/make-plural/-/make-plural-7.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-7.4.0.tgz",
       "integrity": "sha512-4/gC9KVNTV6pvYg2gFeQYTW3mWaoJt7WZE5vrp1KnQDgW92JtYZnzmZT81oj/dUTqAIu0ufI2x3dkgu3bB1tYg==",
       "license": "Unicode-DFS-2016"
     },
     "node_modules/markdown-it": {
       "version": "14.1.1",
-      "resolved": "https://npm.sinequa.com/markdown-it/-/markdown-it-14.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
       "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
       "license": "MIT",
       "dependencies": {
@@ -8622,7 +8622,7 @@
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
-      "resolved": "https://npm.sinequa.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "dev": true,
       "license": "MIT",
@@ -8632,13 +8632,13 @@
     },
     "node_modules/mdurl": {
       "version": "2.0.0",
-      "resolved": "https://npm.sinequa.com/mdurl/-/mdurl-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
       "license": "MIT"
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
-      "resolved": "https://npm.sinequa.com/media-typer/-/media-typer-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
       "dev": true,
       "license": "MIT",
@@ -8648,7 +8648,7 @@
     },
     "node_modules/merge-descriptors": {
       "version": "2.0.0",
-      "resolved": "https://npm.sinequa.com/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "dev": true,
       "license": "MIT",
@@ -8661,14 +8661,14 @@
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
-      "resolved": "https://npm.sinequa.com/merge-stream/-/merge-stream-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
-      "resolved": "https://npm.sinequa.com/micromatch/-/micromatch-4.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "license": "MIT",
@@ -8682,7 +8682,7 @@
     },
     "node_modules/micromatch/node_modules/picomatch": {
       "version": "2.3.2",
-      "resolved": "https://npm.sinequa.com/picomatch/-/picomatch-2.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
@@ -8695,7 +8695,7 @@
     },
     "node_modules/mime-db": {
       "version": "1.54.0",
-      "resolved": "https://npm.sinequa.com/mime-db/-/mime-db-1.54.0.tgz",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "dev": true,
       "license": "MIT",
@@ -8705,7 +8705,7 @@
     },
     "node_modules/mime-types": {
       "version": "3.0.2",
-      "resolved": "https://npm.sinequa.com/mime-types/-/mime-types-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "dev": true,
       "license": "MIT",
@@ -8722,7 +8722,7 @@
     },
     "node_modules/mimic-fn": {
       "version": "4.0.0",
-      "resolved": "https://npm.sinequa.com/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
       "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
       "dev": true,
       "license": "MIT",
@@ -8735,7 +8735,7 @@
     },
     "node_modules/mimic-function": {
       "version": "5.0.1",
-      "resolved": "https://npm.sinequa.com/mimic-function/-/mimic-function-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
       "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
       "dev": true,
       "license": "MIT",
@@ -8748,7 +8748,7 @@
     },
     "node_modules/minimatch": {
       "version": "9.0.9",
-      "resolved": "https://npm.sinequa.com/minimatch/-/minimatch-9.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
       "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "license": "ISC",
       "dependencies": {
@@ -8763,7 +8763,7 @@
     },
     "node_modules/minipass": {
       "version": "7.1.2",
-      "resolved": "https://npm.sinequa.com/minipass/-/minipass-7.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
       "license": "ISC",
       "engines": {
@@ -8772,7 +8772,7 @@
     },
     "node_modules/minipass-collect": {
       "version": "2.0.1",
-      "resolved": "https://npm.sinequa.com/minipass-collect/-/minipass-collect-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
       "integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
       "dev": true,
       "license": "ISC",
@@ -8785,7 +8785,7 @@
     },
     "node_modules/minipass-fetch": {
       "version": "5.0.1",
-      "resolved": "https://npm.sinequa.com/minipass-fetch/-/minipass-fetch-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-5.0.1.tgz",
       "integrity": "sha512-yHK8pb0iCGat0lDrs/D6RZmCdaBT64tULXjdxjSMAqoDi18Q3qKEUTHypHQZQd9+FYpIS+lkvpq6C/R6SbUeRw==",
       "dev": true,
       "license": "MIT",
@@ -8803,7 +8803,7 @@
     },
     "node_modules/minipass-flush": {
       "version": "1.0.5",
-      "resolved": "https://npm.sinequa.com/minipass-flush/-/minipass-flush-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
       "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
       "dev": true,
       "license": "ISC",
@@ -8816,7 +8816,7 @@
     },
     "node_modules/minipass-flush/node_modules/minipass": {
       "version": "3.3.6",
-      "resolved": "https://npm.sinequa.com/minipass/-/minipass-3.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
       "dev": true,
       "license": "ISC",
@@ -8829,14 +8829,14 @@
     },
     "node_modules/minipass-flush/node_modules/yallist": {
       "version": "4.0.0",
-      "resolved": "https://npm.sinequa.com/yallist/-/yallist-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/minipass-pipeline": {
       "version": "1.2.4",
-      "resolved": "https://npm.sinequa.com/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
       "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
       "dev": true,
       "license": "ISC",
@@ -8849,7 +8849,7 @@
     },
     "node_modules/minipass-pipeline/node_modules/minipass": {
       "version": "3.3.6",
-      "resolved": "https://npm.sinequa.com/minipass/-/minipass-3.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
       "dev": true,
       "license": "ISC",
@@ -8862,14 +8862,14 @@
     },
     "node_modules/minipass-pipeline/node_modules/yallist": {
       "version": "4.0.0",
-      "resolved": "https://npm.sinequa.com/yallist/-/yallist-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/minipass-sized": {
       "version": "2.0.0",
-      "resolved": "https://npm.sinequa.com/minipass-sized/-/minipass-sized-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-2.0.0.tgz",
       "integrity": "sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA==",
       "dev": true,
       "license": "ISC",
@@ -8882,7 +8882,7 @@
     },
     "node_modules/minizlib": {
       "version": "3.1.0",
-      "resolved": "https://npm.sinequa.com/minizlib/-/minizlib-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
       "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
       "license": "MIT",
       "dependencies": {
@@ -8894,13 +8894,13 @@
     },
     "node_modules/moo": {
       "version": "0.5.2",
-      "resolved": "https://npm.sinequa.com/moo/-/moo-0.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
       "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==",
       "license": "BSD-3-Clause"
     },
     "node_modules/mrmime": {
       "version": "2.0.1",
-      "resolved": "https://npm.sinequa.com/mrmime/-/mrmime-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
       "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
       "dev": true,
       "license": "MIT",
@@ -8910,14 +8910,14 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://npm.sinequa.com/ms/-/ms-2.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/msgpackr": {
       "version": "1.11.5",
-      "resolved": "https://npm.sinequa.com/msgpackr/-/msgpackr-1.11.5.tgz",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.5.tgz",
       "integrity": "sha512-UjkUHN0yqp9RWKy0Lplhh+wlpdt9oQBYgULZOiFhV3VclSF1JnSQWZ5r9gORQlNYaUKQoR8itv7g7z1xDDuACA==",
       "dev": true,
       "license": "MIT",
@@ -8928,7 +8928,7 @@
     },
     "node_modules/msgpackr-extract": {
       "version": "3.0.3",
-      "resolved": "https://npm.sinequa.com/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
       "integrity": "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==",
       "dev": true,
       "hasInstallScript": true,
@@ -8951,7 +8951,7 @@
     },
     "node_modules/mute-stream": {
       "version": "2.0.0",
-      "resolved": "https://npm.sinequa.com/mute-stream/-/mute-stream-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
       "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
       "dev": true,
       "license": "ISC",
@@ -8961,7 +8961,7 @@
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
-      "resolved": "https://npm.sinequa.com/nanoid/-/nanoid-3.3.11.tgz",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "funding": [
         {
@@ -8979,7 +8979,7 @@
     },
     "node_modules/negotiator": {
       "version": "1.0.0",
-      "resolved": "https://npm.sinequa.com/negotiator/-/negotiator-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "dev": true,
       "license": "MIT",
@@ -8989,7 +8989,7 @@
     },
     "node_modules/ngx-sonner": {
       "version": "3.1.0",
-      "resolved": "https://npm.sinequa.com/ngx-sonner/-/ngx-sonner-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/ngx-sonner/-/ngx-sonner-3.1.0.tgz",
       "integrity": "sha512-hN5GolhBeVs0gzPNZi2VPnbv/sM+3+aMGCvIjH33MC8LHz+QIiOUWGw3AbnCH/hQxy08AGwkWHVYy1acvXByQQ==",
       "license": "MIT",
       "dependencies": {
@@ -9002,7 +9002,7 @@
     },
     "node_modules/node-addon-api": {
       "version": "6.1.0",
-      "resolved": "https://npm.sinequa.com/node-addon-api/-/node-addon-api-6.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
       "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
       "dev": true,
       "license": "MIT",
@@ -9010,7 +9010,7 @@
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
-      "resolved": "https://npm.sinequa.com/node-fetch/-/node-fetch-2.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "license": "MIT",
       "dependencies": {
@@ -9030,7 +9030,7 @@
     },
     "node_modules/node-gyp": {
       "version": "12.2.0",
-      "resolved": "https://npm.sinequa.com/node-gyp/-/node-gyp-12.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.2.0.tgz",
       "integrity": "sha512-q23WdzrQv48KozXlr0U1v9dwO/k59NHeSzn6loGcasyf0UnSrtzs8kRxM+mfwJSf0DkX0s43hcqgnSO4/VNthQ==",
       "dev": true,
       "license": "MIT",
@@ -9055,7 +9055,7 @@
     },
     "node_modules/node-gyp-build-optional-packages": {
       "version": "5.2.2",
-      "resolved": "https://npm.sinequa.com/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
       "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
       "dev": true,
       "license": "MIT",
@@ -9071,7 +9071,7 @@
     },
     "node_modules/node-gyp/node_modules/isexe": {
       "version": "3.1.1",
-      "resolved": "https://npm.sinequa.com/isexe/-/isexe-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
       "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
       "dev": true,
       "license": "ISC",
@@ -9081,7 +9081,7 @@
     },
     "node_modules/node-gyp/node_modules/proc-log": {
       "version": "6.1.0",
-      "resolved": "https://npm.sinequa.com/proc-log/-/proc-log-6.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
       "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
       "dev": true,
       "license": "ISC",
@@ -9091,7 +9091,7 @@
     },
     "node_modules/node-gyp/node_modules/which": {
       "version": "6.0.0",
-      "resolved": "https://npm.sinequa.com/which/-/which-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.0.tgz",
       "integrity": "sha512-f+gEpIKMR9faW/JgAgPK1D7mekkFoqbmiwvNzuhsHetni20QSgzg9Vhn0g2JSJkkfehQnqdUAx7/e15qS1lPxg==",
       "dev": true,
       "license": "ISC",
@@ -9107,14 +9107,14 @@
     },
     "node_modules/node-releases": {
       "version": "2.0.19",
-      "resolved": "https://npm.sinequa.com/node-releases/-/node-releases-2.0.19.tgz",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/nopt": {
       "version": "9.0.0",
-      "resolved": "https://npm.sinequa.com/nopt/-/nopt-9.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
       "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
       "dev": true,
       "license": "ISC",
@@ -9130,7 +9130,7 @@
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
-      "resolved": "https://npm.sinequa.com/normalize-path/-/normalize-path-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
       "license": "MIT",
@@ -9140,7 +9140,7 @@
     },
     "node_modules/normalize-range": {
       "version": "0.1.2",
-      "resolved": "https://npm.sinequa.com/normalize-range/-/normalize-range-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
       "dev": true,
       "license": "MIT",
@@ -9150,7 +9150,7 @@
     },
     "node_modules/npm-bundled": {
       "version": "5.0.0",
-      "resolved": "https://npm.sinequa.com/npm-bundled/-/npm-bundled-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-5.0.0.tgz",
       "integrity": "sha512-JLSpbzh6UUXIEoqPsYBvVNVmyrjVZ1fzEFbqxKkTJQkWBO3xFzFT+KDnSKQWwOQNbuWRwt5LSD6HOTLGIWzfrw==",
       "dev": true,
       "license": "ISC",
@@ -9163,7 +9163,7 @@
     },
     "node_modules/npm-install-checks": {
       "version": "8.0.0",
-      "resolved": "https://npm.sinequa.com/npm-install-checks/-/npm-install-checks-8.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-8.0.0.tgz",
       "integrity": "sha512-ScAUdMpyzkbpxoNekQ3tNRdFI8SJ86wgKZSQZdUxT+bj0wVFpsEMWnkXP0twVe1gJyNF5apBWDJhhIbgrIViRA==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -9176,7 +9176,7 @@
     },
     "node_modules/npm-normalize-package-bin": {
       "version": "5.0.0",
-      "resolved": "https://npm.sinequa.com/npm-normalize-package-bin/-/npm-normalize-package-bin-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-5.0.0.tgz",
       "integrity": "sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==",
       "dev": true,
       "license": "ISC",
@@ -9186,7 +9186,7 @@
     },
     "node_modules/npm-package-arg": {
       "version": "13.0.2",
-      "resolved": "https://npm.sinequa.com/npm-package-arg/-/npm-package-arg-13.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-13.0.2.tgz",
       "integrity": "sha512-IciCE3SY3uE84Ld8WZU23gAPPV9rIYod4F+rc+vJ7h7cwAJt9Vk6TVsK60ry7Uj3SRS3bqRRIGuTp9YVlk6WNA==",
       "dev": true,
       "license": "ISC",
@@ -9202,7 +9202,7 @@
     },
     "node_modules/npm-package-arg/node_modules/proc-log": {
       "version": "6.1.0",
-      "resolved": "https://npm.sinequa.com/proc-log/-/proc-log-6.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
       "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
       "dev": true,
       "license": "ISC",
@@ -9212,7 +9212,7 @@
     },
     "node_modules/npm-package-arg/node_modules/validate-npm-package-name": {
       "version": "7.0.2",
-      "resolved": "https://npm.sinequa.com/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
       "integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==",
       "dev": true,
       "license": "ISC",
@@ -9222,7 +9222,7 @@
     },
     "node_modules/npm-packlist": {
       "version": "10.0.3",
-      "resolved": "https://npm.sinequa.com/npm-packlist/-/npm-packlist-10.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-10.0.3.tgz",
       "integrity": "sha512-zPukTwJMOu5X5uvm0fztwS5Zxyvmk38H/LfidkOMt3gbZVCyro2cD/ETzwzVPcWZA3JOyPznfUN/nkyFiyUbxg==",
       "dev": true,
       "license": "ISC",
@@ -9236,7 +9236,7 @@
     },
     "node_modules/npm-packlist/node_modules/proc-log": {
       "version": "6.1.0",
-      "resolved": "https://npm.sinequa.com/proc-log/-/proc-log-6.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
       "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
       "dev": true,
       "license": "ISC",
@@ -9246,7 +9246,7 @@
     },
     "node_modules/npm-pick-manifest": {
       "version": "11.0.3",
-      "resolved": "https://npm.sinequa.com/npm-pick-manifest/-/npm-pick-manifest-11.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-11.0.3.tgz",
       "integrity": "sha512-buzyCfeoGY/PxKqmBqn1IUJrZnUi1VVJTdSSRPGI60tJdUhUoSQFhs0zycJokDdOznQentgrpf8LayEHyyYlqQ==",
       "dev": true,
       "license": "ISC",
@@ -9262,7 +9262,7 @@
     },
     "node_modules/npm-registry-fetch": {
       "version": "19.1.1",
-      "resolved": "https://npm.sinequa.com/npm-registry-fetch/-/npm-registry-fetch-19.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-19.1.1.tgz",
       "integrity": "sha512-TakBap6OM1w0H73VZVDf44iFXsOS3h+L4wVMXmbWOQroZgFhMch0juN6XSzBNlD965yIKvWg2dfu7NSiaYLxtw==",
       "dev": true,
       "license": "ISC",
@@ -9282,7 +9282,7 @@
     },
     "node_modules/npm-registry-fetch/node_modules/proc-log": {
       "version": "6.1.0",
-      "resolved": "https://npm.sinequa.com/proc-log/-/proc-log-6.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
       "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
       "dev": true,
       "license": "ISC",
@@ -9292,7 +9292,7 @@
     },
     "node_modules/npm-run-path": {
       "version": "5.3.0",
-      "resolved": "https://npm.sinequa.com/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
       "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
       "dev": true,
       "license": "MIT",
@@ -9308,7 +9308,7 @@
     },
     "node_modules/npm-run-path/node_modules/path-key": {
       "version": "4.0.0",
-      "resolved": "https://npm.sinequa.com/path-key/-/path-key-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
       "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
       "dev": true,
       "license": "MIT",
@@ -9321,7 +9321,7 @@
     },
     "node_modules/nth-check": {
       "version": "2.1.1",
-      "resolved": "https://npm.sinequa.com/nth-check/-/nth-check-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
       "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -9334,7 +9334,7 @@
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
-      "resolved": "https://npm.sinequa.com/object-assign/-/object-assign-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true,
       "license": "MIT",
@@ -9344,7 +9344,7 @@
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
-      "resolved": "https://npm.sinequa.com/object-inspect/-/object-inspect-1.13.4.tgz",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "dev": true,
       "license": "MIT",
@@ -9357,7 +9357,7 @@
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
-      "resolved": "https://npm.sinequa.com/on-finished/-/on-finished-2.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "dev": true,
       "license": "MIT",
@@ -9370,7 +9370,7 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://npm.sinequa.com/once/-/once-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "license": "ISC",
       "dependencies": {
@@ -9379,7 +9379,7 @@
     },
     "node_modules/onetime": {
       "version": "6.0.0",
-      "resolved": "https://npm.sinequa.com/onetime/-/onetime-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
       "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
       "dev": true,
       "license": "MIT",
@@ -9395,7 +9395,7 @@
     },
     "node_modules/ora": {
       "version": "5.4.1",
-      "resolved": "https://npm.sinequa.com/ora/-/ora-5.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
       "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
       "license": "MIT",
       "dependencies": {
@@ -9418,7 +9418,7 @@
     },
     "node_modules/ora/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://npm.sinequa.com/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
       "engines": {
@@ -9427,7 +9427,7 @@
     },
     "node_modules/ora/node_modules/cli-cursor": {
       "version": "3.1.0",
-      "resolved": "https://npm.sinequa.com/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
       "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
       "license": "MIT",
       "dependencies": {
@@ -9439,7 +9439,7 @@
     },
     "node_modules/ora/node_modules/mimic-fn": {
       "version": "2.1.0",
-      "resolved": "https://npm.sinequa.com/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "license": "MIT",
       "engines": {
@@ -9448,7 +9448,7 @@
     },
     "node_modules/ora/node_modules/onetime": {
       "version": "5.1.2",
-      "resolved": "https://npm.sinequa.com/onetime/-/onetime-5.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "license": "MIT",
       "dependencies": {
@@ -9463,7 +9463,7 @@
     },
     "node_modules/ora/node_modules/restore-cursor": {
       "version": "3.1.0",
-      "resolved": "https://npm.sinequa.com/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
       "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
       "license": "MIT",
       "dependencies": {
@@ -9476,13 +9476,13 @@
     },
     "node_modules/ora/node_modules/signal-exit": {
       "version": "3.0.7",
-      "resolved": "https://npm.sinequa.com/signal-exit/-/signal-exit-3.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
     },
     "node_modules/ora/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://npm.sinequa.com/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
       "dependencies": {
@@ -9494,7 +9494,7 @@
     },
     "node_modules/ordered-binary": {
       "version": "1.6.0",
-      "resolved": "https://npm.sinequa.com/ordered-binary/-/ordered-binary-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.6.0.tgz",
       "integrity": "sha512-IQh2aMfMIDbPjI/8a3Edr+PiOpcsB7yo8NdW7aHWVaoR/pcDldunMvnnwbk/auPGqmKeAdxtZl7MHX/QmPwhvQ==",
       "dev": true,
       "license": "MIT",
@@ -9502,7 +9502,7 @@
     },
     "node_modules/p-map": {
       "version": "7.0.4",
-      "resolved": "https://npm.sinequa.com/p-map/-/p-map-7.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
       "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
       "dev": true,
       "license": "MIT",
@@ -9515,13 +9515,13 @@
     },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
-      "resolved": "https://npm.sinequa.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
     },
     "node_modules/pacote": {
       "version": "21.0.4",
-      "resolved": "https://npm.sinequa.com/pacote/-/pacote-21.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/pacote/-/pacote-21.0.4.tgz",
       "integrity": "sha512-RplP/pDW0NNNDh3pnaoIWYPvNenS7UqMbXyvMqJczosiFWTeGGwJC2NQBLqKf4rGLFfwCOnntw1aEp9Jiqm1MA==",
       "dev": true,
       "license": "ISC",
@@ -9553,7 +9553,7 @@
     },
     "node_modules/pacote/node_modules/proc-log": {
       "version": "6.1.0",
-      "resolved": "https://npm.sinequa.com/proc-log/-/proc-log-6.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
       "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
       "dev": true,
       "license": "ISC",
@@ -9563,7 +9563,7 @@
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
-      "resolved": "https://npm.sinequa.com/parent-module/-/parent-module-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "license": "MIT",
       "dependencies": {
@@ -9575,7 +9575,7 @@
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
-      "resolved": "https://npm.sinequa.com/parse-json/-/parse-json-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
       "license": "MIT",
       "dependencies": {
@@ -9593,13 +9593,13 @@
     },
     "node_modules/parse-json/node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
-      "resolved": "https://npm.sinequa.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT"
     },
     "node_modules/parse5": {
       "version": "8.0.0",
-      "resolved": "https://npm.sinequa.com/parse5/-/parse5-8.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
       "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
       "license": "MIT",
       "dependencies": {
@@ -9611,7 +9611,7 @@
     },
     "node_modules/parse5-html-rewriting-stream": {
       "version": "8.0.0",
-      "resolved": "https://npm.sinequa.com/parse5-html-rewriting-stream/-/parse5-html-rewriting-stream-8.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse5-html-rewriting-stream/-/parse5-html-rewriting-stream-8.0.0.tgz",
       "integrity": "sha512-wzh11mj8KKkno1pZEu+l2EVeWsuKDfR5KNWZOTsslfUX8lPDZx77m9T0kIoAVkFtD1nx6YF8oh4BnPHvxMtNMw==",
       "dev": true,
       "license": "MIT",
@@ -9626,7 +9626,7 @@
     },
     "node_modules/parse5-html-rewriting-stream/node_modules/entities": {
       "version": "6.0.1",
-      "resolved": "https://npm.sinequa.com/entities/-/entities-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -9639,7 +9639,7 @@
     },
     "node_modules/parse5-sax-parser": {
       "version": "8.0.0",
-      "resolved": "https://npm.sinequa.com/parse5-sax-parser/-/parse5-sax-parser-8.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse5-sax-parser/-/parse5-sax-parser-8.0.0.tgz",
       "integrity": "sha512-/dQ8UzHZwnrzs3EvDj6IkKrD/jIZyTlB+8XrHJvcjNgRdmWruNdN9i9RK/JtxakmlUdPwKubKPTCqvbTgzGhrw==",
       "dev": true,
       "license": "MIT",
@@ -9652,7 +9652,7 @@
     },
     "node_modules/parse5/node_modules/entities": {
       "version": "6.0.1",
-      "resolved": "https://npm.sinequa.com/entities/-/entities-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
       "license": "BSD-2-Clause",
       "engines": {
@@ -9664,7 +9664,7 @@
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
-      "resolved": "https://npm.sinequa.com/parseurl/-/parseurl-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "dev": true,
       "license": "MIT",
@@ -9674,7 +9674,7 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "resolved": "https://npm.sinequa.com/path-key/-/path-key-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "license": "MIT",
       "engines": {
@@ -9683,14 +9683,14 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
-      "resolved": "https://npm.sinequa.com/path-parse/-/path-parse-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/path-scurry": {
       "version": "1.11.1",
-      "resolved": "https://npm.sinequa.com/path-scurry/-/path-scurry-1.11.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -9706,13 +9706,13 @@
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
       "version": "10.4.3",
-      "resolved": "https://npm.sinequa.com/lru-cache/-/lru-cache-10.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
     },
     "node_modules/path-to-regexp": {
       "version": "8.4.1",
-      "resolved": "https://npm.sinequa.com/path-to-regexp/-/path-to-regexp-8.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.1.tgz",
       "integrity": "sha512-fvU78fIjZ+SBM9YwCknCvKOUKkLVqtWDVctl0s7xIqfmfb38t2TT4ZU2gHm+Z8xGwgW+QWEU3oQSAzIbo89Ggw==",
       "dev": true,
       "license": "MIT",
@@ -9723,7 +9723,7 @@
     },
     "node_modules/path-type": {
       "version": "4.0.0",
-      "resolved": "https://npm.sinequa.com/path-type/-/path-type-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "license": "MIT",
       "engines": {
@@ -9732,13 +9732,13 @@
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://npm.sinequa.com/picocolors/-/picocolors-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.4",
-      "resolved": "https://npm.sinequa.com/picomatch/-/picomatch-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
@@ -9751,7 +9751,7 @@
     },
     "node_modules/pidtree": {
       "version": "0.6.0",
-      "resolved": "https://npm.sinequa.com/pidtree/-/pidtree-0.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
       "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
       "dev": true,
       "license": "MIT",
@@ -9764,7 +9764,7 @@
     },
     "node_modules/piscina": {
       "version": "5.1.3",
-      "resolved": "https://npm.sinequa.com/piscina/-/piscina-5.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/piscina/-/piscina-5.1.3.tgz",
       "integrity": "sha512-0u3N7H4+hbr40KjuVn2uNhOcthu/9usKhnw5vT3J7ply79v3D3M8naI00el9Klcy16x557VsEkkUQaHCWFXC/g==",
       "dev": true,
       "license": "MIT",
@@ -9777,7 +9777,7 @@
     },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",
-      "resolved": "https://npm.sinequa.com/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
       "dev": true,
       "license": "MIT",
@@ -9787,7 +9787,7 @@
     },
     "node_modules/postcss": {
       "version": "8.5.12",
-      "resolved": "https://npm.sinequa.com/postcss/-/postcss-8.5.12.tgz",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
       "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "funding": [
         {
@@ -9815,14 +9815,14 @@
     },
     "node_modules/postcss-media-query-parser": {
       "version": "0.2.3",
-      "resolved": "https://npm.sinequa.com/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
       "integrity": "sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/postcss-selector-parser": {
       "version": "6.0.10",
-      "resolved": "https://npm.sinequa.com/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
       "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
       "dev": true,
       "license": "MIT",
@@ -9836,14 +9836,14 @@
     },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
-      "resolved": "https://npm.sinequa.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/prettier": {
       "version": "3.5.3",
-      "resolved": "https://npm.sinequa.com/prettier/-/prettier-3.5.3.tgz",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
       "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "dev": true,
       "license": "MIT",
@@ -9859,7 +9859,7 @@
     },
     "node_modules/prettier-plugin-package": {
       "version": "1.4.0",
-      "resolved": "https://npm.sinequa.com/prettier-plugin-package/-/prettier-plugin-package-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-package/-/prettier-plugin-package-1.4.0.tgz",
       "integrity": "sha512-jy8UjgHadyznzWfunyjPQPqE2Y92TVF3Q0O829X6pk/ARoKn0vtSu+mtKIsmikZYb2N50mV6vRIqCf19XdOdIg==",
       "dev": true,
       "license": "MPL-2.0",
@@ -9872,7 +9872,7 @@
     },
     "node_modules/prettier-plugin-tailwindcss": {
       "version": "0.6.12",
-      "resolved": "https://npm.sinequa.com/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.12.tgz",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.12.tgz",
       "integrity": "sha512-OuTQKoqNwV7RnxTPwXWzOFXy6Jc4z8oeRZYGuMpRyG3WbuR3jjXdQFK8qFBMBx8UHWdHrddARz2fgUenild6aw==",
       "dev": true,
       "license": "MIT",
@@ -9951,7 +9951,7 @@
     },
     "node_modules/prismjs": {
       "version": "1.30.0",
-      "resolved": "https://npm.sinequa.com/prismjs/-/prismjs-1.30.0.tgz",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
       "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
       "license": "MIT",
       "engines": {
@@ -9960,7 +9960,7 @@
     },
     "node_modules/prismjs-components-importer": {
       "version": "0.2.0",
-      "resolved": "https://npm.sinequa.com/prismjs-components-importer/-/prismjs-components-importer-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/prismjs-components-importer/-/prismjs-components-importer-0.2.0.tgz",
       "integrity": "sha512-2WJBqocATZOOoApIH9y6QmZG7dkQsX9BKexbW6LjMZ9QBAxoDsmoAKTzOt3g9xgpTQVEydmkS4I4tSlguJ52Kg==",
       "license": "MIT",
       "peerDependencies": {
@@ -9969,7 +9969,7 @@
     },
     "node_modules/proc-log": {
       "version": "5.0.0",
-      "resolved": "https://npm.sinequa.com/proc-log/-/proc-log-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-5.0.0.tgz",
       "integrity": "sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==",
       "dev": true,
       "license": "ISC",
@@ -9979,7 +9979,7 @@
     },
     "node_modules/promise-retry": {
       "version": "2.0.1",
-      "resolved": "https://npm.sinequa.com/promise-retry/-/promise-retry-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
       "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
       "dev": true,
       "license": "MIT",
@@ -9993,7 +9993,7 @@
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
-      "resolved": "https://npm.sinequa.com/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "dev": true,
       "license": "MIT",
@@ -10007,7 +10007,7 @@
     },
     "node_modules/psl": {
       "version": "1.15.0",
-      "resolved": "https://npm.sinequa.com/psl/-/psl-1.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
       "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
       "license": "MIT",
       "dependencies": {
@@ -10019,7 +10019,7 @@
     },
     "node_modules/punycode": {
       "version": "2.3.1",
-      "resolved": "https://npm.sinequa.com/punycode/-/punycode-2.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "license": "MIT",
       "engines": {
@@ -10028,7 +10028,7 @@
     },
     "node_modules/punycode.js": {
       "version": "2.3.1",
-      "resolved": "https://npm.sinequa.com/punycode.js/-/punycode.js-2.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
       "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "license": "MIT",
       "engines": {
@@ -10037,7 +10037,7 @@
     },
     "node_modules/qs": {
       "version": "6.15.0",
-      "resolved": "https://npm.sinequa.com/qs/-/qs-6.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
       "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -10053,13 +10053,13 @@
     },
     "node_modules/querystringify": {
       "version": "2.2.0",
-      "resolved": "https://npm.sinequa.com/querystringify/-/querystringify-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
       "license": "MIT"
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
-      "resolved": "https://npm.sinequa.com/range-parser/-/range-parser-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "dev": true,
       "license": "MIT",
@@ -10069,7 +10069,7 @@
     },
     "node_modules/raw-body": {
       "version": "3.0.2",
-      "resolved": "https://npm.sinequa.com/raw-body/-/raw-body-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
       "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "dev": true,
       "license": "MIT",
@@ -10085,7 +10085,7 @@
     },
     "node_modules/readable-stream": {
       "version": "3.6.2",
-      "resolved": "https://npm.sinequa.com/readable-stream/-/readable-stream-3.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
       "dependencies": {
@@ -10099,7 +10099,7 @@
     },
     "node_modules/readdirp": {
       "version": "4.1.2",
-      "resolved": "https://npm.sinequa.com/readdirp/-/readdirp-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
       "dev": true,
       "license": "MIT",
@@ -10113,14 +10113,14 @@
     },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
-      "resolved": "https://npm.sinequa.com/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/replace-in-file": {
       "version": "7.2.0",
-      "resolved": "https://npm.sinequa.com/replace-in-file/-/replace-in-file-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/replace-in-file/-/replace-in-file-7.2.0.tgz",
       "integrity": "sha512-CiLXVop3o8/h2Kd1PwKPPimmS9wUV0Ki6Fl8+1ITD35nB3Gl/PrW5IONpTE0AXk0z4v8WYcpEpdeZqMXvSnWpg==",
       "license": "MIT",
       "dependencies": {
@@ -10137,7 +10137,7 @@
     },
     "node_modules/replace-in-file/node_modules/glob": {
       "version": "8.1.0",
-      "resolved": "https://npm.sinequa.com/glob/-/glob-8.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
       "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
       "license": "ISC",
       "dependencies": {
@@ -10156,7 +10156,7 @@
     },
     "node_modules/replace-in-file/node_modules/minimatch": {
       "version": "5.1.9",
-      "resolved": "https://npm.sinequa.com/minimatch/-/minimatch-5.1.9.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
       "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "license": "ISC",
       "dependencies": {
@@ -10168,7 +10168,7 @@
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
-      "resolved": "https://npm.sinequa.com/require-directory/-/require-directory-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "license": "MIT",
       "engines": {
@@ -10177,7 +10177,7 @@
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
-      "resolved": "https://npm.sinequa.com/require-from-string/-/require-from-string-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
@@ -10187,13 +10187,13 @@
     },
     "node_modules/requires-port": {
       "version": "1.0.0",
-      "resolved": "https://npm.sinequa.com/requires-port/-/requires-port-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.10",
-      "resolved": "https://npm.sinequa.com/resolve/-/resolve-1.22.10.tgz",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
       "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
       "dev": true,
       "license": "MIT",
@@ -10214,7 +10214,7 @@
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
-      "resolved": "https://npm.sinequa.com/resolve-from/-/resolve-from-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "license": "MIT",
       "engines": {
@@ -10223,7 +10223,7 @@
     },
     "node_modules/restore-cursor": {
       "version": "5.1.0",
-      "resolved": "https://npm.sinequa.com/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
       "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
       "dev": true,
       "license": "MIT",
@@ -10240,7 +10240,7 @@
     },
     "node_modules/restore-cursor/node_modules/onetime": {
       "version": "7.0.0",
-      "resolved": "https://npm.sinequa.com/onetime/-/onetime-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
       "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
       "dev": true,
       "license": "MIT",
@@ -10256,7 +10256,7 @@
     },
     "node_modules/retry": {
       "version": "0.12.0",
-      "resolved": "https://npm.sinequa.com/retry/-/retry-0.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
       "dev": true,
       "license": "MIT",
@@ -10266,14 +10266,14 @@
     },
     "node_modules/rfdc": {
       "version": "1.4.1",
-      "resolved": "https://npm.sinequa.com/rfdc/-/rfdc-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.13",
-      "resolved": "https://npm.sinequa.com/rolldown/-/rolldown-1.0.0-rc.13.tgz",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.13.tgz",
       "integrity": "sha512-bvVj8YJmf0rq4pSFmH7laLa6pYrhghv3PRzrCdRAr23g66zOKVJ4wkvFtgohtPLWmthgg8/rkaqRHrpUEh0Zbw==",
       "dev": true,
       "license": "MIT",
@@ -10307,7 +10307,7 @@
     },
     "node_modules/rollup": {
       "version": "4.59.0",
-      "resolved": "https://npm.sinequa.com/rollup/-/rollup-4.59.0.tgz",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
@@ -10352,7 +10352,7 @@
     },
     "node_modules/router": {
       "version": "2.2.0",
-      "resolved": "https://npm.sinequa.com/router/-/router-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
       "dev": true,
       "license": "MIT",
@@ -10369,7 +10369,7 @@
     },
     "node_modules/rxjs": {
       "version": "7.8.2",
-      "resolved": "https://npm.sinequa.com/rxjs/-/rxjs-7.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -10378,7 +10378,7 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
-      "resolved": "https://npm.sinequa.com/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "funding": [
         {
@@ -10398,26 +10398,26 @@
     },
     "node_modules/safe-identifier": {
       "version": "0.4.2",
-      "resolved": "https://npm.sinequa.com/safe-identifier/-/safe-identifier-0.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/safe-identifier/-/safe-identifier-0.4.2.tgz",
       "integrity": "sha512-6pNbSMW6OhAi9j+N8V+U715yBQsaWJ7eyEUaOrawX+isg5ZxhUlV1NipNtgaKHmFGiABwt+ZF04Ii+3Xjkg+8w==",
       "license": "ISC"
     },
     "node_modules/safecolor": {
       "version": "1.0.1",
-      "resolved": "https://npm.sinequa.com/safecolor/-/safecolor-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/safecolor/-/safecolor-1.0.1.tgz",
       "integrity": "sha512-Gv+4W+zKdViltaXv36U8/4BIOBxNxN8/mfPVyiO7qobCcSFsBK8+UtrclJizecKgK02458feT/9PXZXLxo0YxA==",
       "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://npm.sinequa.com/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/sass": {
       "version": "1.90.0",
-      "resolved": "https://npm.sinequa.com/sass/-/sass-1.90.0.tgz",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.90.0.tgz",
       "integrity": "sha512-9GUyuksjw70uNpb1MTYWsH9MQHOHY6kwfnkafC24+7aOMZn9+rVMBxRbLvw756mrBFbIsFg6Xw9IkR2Fnn3k+Q==",
       "dev": true,
       "license": "MIT",
@@ -10438,7 +10438,7 @@
     },
     "node_modules/semver": {
       "version": "7.6.3",
-      "resolved": "https://npm.sinequa.com/semver/-/semver-7.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
       "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
       "license": "ISC",
@@ -10451,7 +10451,7 @@
     },
     "node_modules/send": {
       "version": "1.2.1",
-      "resolved": "https://npm.sinequa.com/send/-/send-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
       "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "dev": true,
       "license": "MIT",
@@ -10478,7 +10478,7 @@
     },
     "node_modules/serve-static": {
       "version": "2.2.1",
-      "resolved": "https://npm.sinequa.com/serve-static/-/serve-static-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
       "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "dev": true,
       "license": "MIT",
@@ -10498,20 +10498,20 @@
     },
     "node_modules/set-cookie-parser": {
       "version": "2.7.1",
-      "resolved": "https://npm.sinequa.com/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
       "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
       "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
-      "resolved": "https://npm.sinequa.com/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "resolved": "https://npm.sinequa.com/shebang-command/-/shebang-command-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "license": "MIT",
       "dependencies": {
@@ -10523,7 +10523,7 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "resolved": "https://npm.sinequa.com/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "license": "MIT",
       "engines": {
@@ -10532,7 +10532,7 @@
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
-      "resolved": "https://npm.sinequa.com/side-channel/-/side-channel-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "dev": true,
       "license": "MIT",
@@ -10552,7 +10552,7 @@
     },
     "node_modules/side-channel-list": {
       "version": "1.0.0",
-      "resolved": "https://npm.sinequa.com/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
       "dev": true,
       "license": "MIT",
@@ -10569,7 +10569,7 @@
     },
     "node_modules/side-channel-map": {
       "version": "1.0.1",
-      "resolved": "https://npm.sinequa.com/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "dev": true,
       "license": "MIT",
@@ -10588,7 +10588,7 @@
     },
     "node_modules/side-channel-weakmap": {
       "version": "1.0.2",
-      "resolved": "https://npm.sinequa.com/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "dev": true,
       "license": "MIT",
@@ -10608,7 +10608,7 @@
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
-      "resolved": "https://npm.sinequa.com/signal-exit/-/signal-exit-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "license": "ISC",
       "engines": {
@@ -10620,7 +10620,7 @@
     },
     "node_modules/sigstore": {
       "version": "4.1.0",
-      "resolved": "https://npm.sinequa.com/sigstore/-/sigstore-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/sigstore/-/sigstore-4.1.0.tgz",
       "integrity": "sha512-/fUgUhYghuLzVT/gaJoeVehLCgZiUxPCPMcyVNY0lIf/cTCz58K/WTI7PefDarXxp9nUKpEwg1yyz3eSBMTtgA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -10638,7 +10638,7 @@
     },
     "node_modules/slice-ansi": {
       "version": "5.0.0",
-      "resolved": "https://npm.sinequa.com/slice-ansi/-/slice-ansi-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
       "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
       "dev": true,
       "license": "MIT",
@@ -10655,7 +10655,7 @@
     },
     "node_modules/slice-ansi/node_modules/ansi-styles": {
       "version": "6.2.1",
-      "resolved": "https://npm.sinequa.com/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
       "dev": true,
       "license": "MIT",
@@ -10668,7 +10668,7 @@
     },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
-      "resolved": "https://npm.sinequa.com/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
       "dev": true,
       "license": "MIT",
@@ -10679,7 +10679,7 @@
     },
     "node_modules/socks": {
       "version": "2.8.7",
-      "resolved": "https://npm.sinequa.com/socks/-/socks-2.8.7.tgz",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
       "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
       "dev": true,
       "license": "MIT",
@@ -10694,7 +10694,7 @@
     },
     "node_modules/socks-proxy-agent": {
       "version": "8.0.5",
-      "resolved": "https://npm.sinequa.com/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
       "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
       "dev": true,
       "license": "MIT",
@@ -10709,7 +10709,7 @@
     },
     "node_modules/source-map": {
       "version": "0.7.6",
-      "resolved": "https://npm.sinequa.com/source-map/-/source-map-0.7.6.tgz",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
       "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -10719,7 +10719,7 @@
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "resolved": "https://npm.sinequa.com/source-map-js/-/source-map-js-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "license": "BSD-3-Clause",
       "engines": {
@@ -10728,7 +10728,7 @@
     },
     "node_modules/source-map-support": {
       "version": "0.5.21",
-      "resolved": "https://npm.sinequa.com/source-map-support/-/source-map-support-0.5.21.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
       "license": "MIT",
@@ -10739,7 +10739,7 @@
     },
     "node_modules/source-map-support/node_modules/source-map": {
       "version": "0.6.1",
-      "resolved": "https://npm.sinequa.com/source-map/-/source-map-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -10749,7 +10749,7 @@
     },
     "node_modules/spdx-correct": {
       "version": "3.2.0",
-      "resolved": "https://npm.sinequa.com/spdx-correct/-/spdx-correct-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
       "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -10760,14 +10760,14 @@
     },
     "node_modules/spdx-exceptions": {
       "version": "2.5.0",
-      "resolved": "https://npm.sinequa.com/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
       "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
       "dev": true,
       "license": "CC-BY-3.0"
     },
     "node_modules/spdx-expression-parse": {
       "version": "3.0.1",
-      "resolved": "https://npm.sinequa.com/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
       "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
       "dev": true,
       "license": "MIT",
@@ -10778,14 +10778,14 @@
     },
     "node_modules/spdx-license-ids": {
       "version": "3.0.22",
-      "resolved": "https://npm.sinequa.com/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
       "integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
       "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/ssri": {
       "version": "13.0.0",
-      "resolved": "https://npm.sinequa.com/ssri/-/ssri-13.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.0.tgz",
       "integrity": "sha512-yizwGBpbCn4YomB2lzhZqrHLJoqFGXihNbib3ozhqF/cIp5ue+xSmOQrjNasEE62hFxsCcg/V/z23t4n8jMEng==",
       "dev": true,
       "license": "ISC",
@@ -10798,7 +10798,7 @@
     },
     "node_modules/statuses": {
       "version": "2.0.2",
-      "resolved": "https://npm.sinequa.com/statuses/-/statuses-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "dev": true,
       "license": "MIT",
@@ -10808,7 +10808,7 @@
     },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",
-      "resolved": "https://npm.sinequa.com/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
       "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
       "dev": true,
       "license": "MIT",
@@ -10821,7 +10821,7 @@
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
-      "resolved": "https://npm.sinequa.com/string_decoder/-/string_decoder-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "license": "MIT",
       "dependencies": {
@@ -10830,7 +10830,7 @@
     },
     "node_modules/string-argv": {
       "version": "0.3.2",
-      "resolved": "https://npm.sinequa.com/string-argv/-/string-argv-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
       "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
       "dev": true,
       "license": "MIT",
@@ -10840,7 +10840,7 @@
     },
     "node_modules/string-width": {
       "version": "5.1.2",
-      "resolved": "https://npm.sinequa.com/string-width/-/string-width-5.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
       "license": "MIT",
       "dependencies": {
@@ -10858,7 +10858,7 @@
     "node_modules/string-width-cjs": {
       "name": "string-width",
       "version": "4.2.3",
-      "resolved": "https://npm.sinequa.com/string-width/-/string-width-4.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "license": "MIT",
       "dependencies": {
@@ -10872,7 +10872,7 @@
     },
     "node_modules/string-width-cjs/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://npm.sinequa.com/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
       "engines": {
@@ -10881,13 +10881,13 @@
     },
     "node_modules/string-width-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://npm.sinequa.com/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
     },
     "node_modules/string-width-cjs/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://npm.sinequa.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "license": "MIT",
       "engines": {
@@ -10896,7 +10896,7 @@
     },
     "node_modules/string-width-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://npm.sinequa.com/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
       "dependencies": {
@@ -10908,7 +10908,7 @@
     },
     "node_modules/strip-ansi": {
       "version": "7.1.0",
-      "resolved": "https://npm.sinequa.com/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
       "license": "MIT",
       "dependencies": {
@@ -10924,7 +10924,7 @@
     "node_modules/strip-ansi-cjs": {
       "name": "strip-ansi",
       "version": "6.0.1",
-      "resolved": "https://npm.sinequa.com/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
       "dependencies": {
@@ -10936,7 +10936,7 @@
     },
     "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://npm.sinequa.com/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
       "engines": {
@@ -10945,7 +10945,7 @@
     },
     "node_modules/strip-final-newline": {
       "version": "3.0.0",
-      "resolved": "https://npm.sinequa.com/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
       "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
       "dev": true,
       "license": "MIT",
@@ -10958,7 +10958,7 @@
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "https://npm.sinequa.com/supports-color/-/supports-color-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "license": "MIT",
       "dependencies": {
@@ -10970,7 +10970,7 @@
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
-      "resolved": "https://npm.sinequa.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true,
       "license": "MIT",
@@ -10983,7 +10983,7 @@
     },
     "node_modules/tailwind-merge": {
       "version": "2.6.0",
-      "resolved": "https://npm.sinequa.com/tailwind-merge/-/tailwind-merge-2.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.0.tgz",
       "integrity": "sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA==",
       "dev": true,
       "license": "MIT",
@@ -10994,13 +10994,13 @@
     },
     "node_modules/tailwindcss": {
       "version": "4.1.10",
-      "resolved": "https://npm.sinequa.com/tailwindcss/-/tailwindcss-4.1.10.tgz",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.10.tgz",
       "integrity": "sha512-P3nr6WkvKV/ONsTzj6Gb57sWPMX29EPNPopo7+FcpkQaNsrNpZ1pv8QmrYI2RqEKD7mlGqLnGovlcYnBK0IqUA==",
       "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.2.2",
-      "resolved": "https://npm.sinequa.com/tapable/-/tapable-2.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.2.tgz",
       "integrity": "sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==",
       "license": "MIT",
       "engines": {
@@ -11009,7 +11009,7 @@
     },
     "node_modules/tar": {
       "version": "7.5.11",
-      "resolved": "https://npm.sinequa.com/tar/-/tar-7.5.11.tgz",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.11.tgz",
       "integrity": "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -11025,7 +11025,7 @@
     },
     "node_modules/tar/node_modules/yallist": {
       "version": "5.0.0",
-      "resolved": "https://npm.sinequa.com/yallist/-/yallist-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
       "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -11034,7 +11034,7 @@
     },
     "node_modules/tinyglobby": {
       "version": "0.2.14",
-      "resolved": "https://npm.sinequa.com/tinyglobby/-/tinyglobby-0.2.14.tgz",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
       "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
       "dev": true,
       "license": "MIT",
@@ -11051,7 +11051,7 @@
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
-      "resolved": "https://npm.sinequa.com/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
       "license": "MIT",
@@ -11064,7 +11064,7 @@
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
-      "resolved": "https://npm.sinequa.com/toidentifier/-/toidentifier-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "dev": true,
       "license": "MIT",
@@ -11074,7 +11074,7 @@
     },
     "node_modules/tough-cookie": {
       "version": "4.1.4",
-      "resolved": "https://npm.sinequa.com/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
       "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -11089,7 +11089,7 @@
     },
     "node_modules/tough-cookie/node_modules/universalify": {
       "version": "0.2.0",
-      "resolved": "https://npm.sinequa.com/universalify/-/universalify-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
       "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
       "license": "MIT",
       "engines": {
@@ -11098,19 +11098,19 @@
     },
     "node_modules/tr46": {
       "version": "0.0.3",
-      "resolved": "https://npm.sinequa.com/tr46/-/tr46-0.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
       "license": "MIT"
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://npm.sinequa.com/tslib/-/tslib-2.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
     "node_modules/tuf-js": {
       "version": "4.1.0",
-      "resolved": "https://npm.sinequa.com/tuf-js/-/tuf-js-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/tuf-js/-/tuf-js-4.1.0.tgz",
       "integrity": "sha512-50QV99kCKH5P/Vs4E2Gzp7BopNV+KzTXqWeaxrfu5IQJBOULRsTIS9seSsOVT8ZnGXzCyx55nYWAi4qJzpZKEQ==",
       "dev": true,
       "license": "MIT",
@@ -11125,7 +11125,7 @@
     },
     "node_modules/type-is": {
       "version": "2.0.1",
-      "resolved": "https://npm.sinequa.com/type-is/-/type-is-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
       "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
       "dev": true,
       "license": "MIT",
@@ -11140,7 +11140,7 @@
     },
     "node_modules/typescript": {
       "version": "5.8.3",
-      "resolved": "https://npm.sinequa.com/typescript/-/typescript-5.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -11154,7 +11154,7 @@
     },
     "node_modules/typical": {
       "version": "4.0.0",
-      "resolved": "https://npm.sinequa.com/typical/-/typical-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
       "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
       "dev": true,
       "license": "MIT",
@@ -11164,20 +11164,20 @@
     },
     "node_modules/uc.micro": {
       "version": "2.1.0",
-      "resolved": "https://npm.sinequa.com/uc.micro/-/uc.micro-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
-      "resolved": "https://npm.sinequa.com/undici-types/-/undici-types-6.21.0.tgz",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/unique-filename": {
       "version": "5.0.0",
-      "resolved": "https://npm.sinequa.com/unique-filename/-/unique-filename-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-5.0.0.tgz",
       "integrity": "sha512-2RaJTAvAb4owyjllTfXzFClJ7WsGxlykkPvCr9pA//LD9goVq+m4PPAeBgNodGZ7nSrntT/auWpJ6Y5IFXcfjg==",
       "dev": true,
       "license": "ISC",
@@ -11190,7 +11190,7 @@
     },
     "node_modules/unique-slug": {
       "version": "6.0.0",
-      "resolved": "https://npm.sinequa.com/unique-slug/-/unique-slug-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-6.0.0.tgz",
       "integrity": "sha512-4Lup7Ezn8W3d52/xBhZBVdx323ckxa7DEvd9kPQHppTkLoJXw6ltrBCyj5pnrxj0qKDxYMJ56CoxNuFCscdTiw==",
       "dev": true,
       "license": "ISC",
@@ -11203,7 +11203,7 @@
     },
     "node_modules/universalify": {
       "version": "2.0.1",
-      "resolved": "https://npm.sinequa.com/universalify/-/universalify-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "license": "MIT",
       "engines": {
@@ -11212,7 +11212,7 @@
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
-      "resolved": "https://npm.sinequa.com/unpipe/-/unpipe-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true,
       "license": "MIT",
@@ -11222,7 +11222,7 @@
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
-      "resolved": "https://npm.sinequa.com/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
       "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
       "dev": true,
       "funding": [
@@ -11253,7 +11253,7 @@
     },
     "node_modules/url-parse": {
       "version": "1.5.10",
-      "resolved": "https://npm.sinequa.com/url-parse/-/url-parse-1.5.10.tgz",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
       "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
       "license": "MIT",
       "dependencies": {
@@ -11263,13 +11263,13 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://npm.sinequa.com/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "license": "MIT"
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
-      "resolved": "https://npm.sinequa.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "license": "Apache-2.0",
@@ -11280,7 +11280,7 @@
     },
     "node_modules/validate-npm-package-name": {
       "version": "6.0.1",
-      "resolved": "https://npm.sinequa.com/validate-npm-package-name/-/validate-npm-package-name-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-6.0.1.tgz",
       "integrity": "sha512-OaI//3H0J7ZkR1OqlhGA8cA+Cbk/2xFOQpJOt5+s27/ta9eZwpeervh4Mxh4w0im/kdgktowaqVNR7QOrUd7Yg==",
       "dev": true,
       "license": "ISC",
@@ -11290,13 +11290,13 @@
     },
     "node_modules/vanillajs-datepicker": {
       "version": "1.3.4",
-      "resolved": "https://npm.sinequa.com/vanillajs-datepicker/-/vanillajs-datepicker-1.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/vanillajs-datepicker/-/vanillajs-datepicker-1.3.4.tgz",
       "integrity": "sha512-waOyp2Ay+K1VA/B5cNlFgSNzFR9efCVKaoyMyNEAhAwmKLzMB9nCJs6Vqmo6HuHWA98VEHXbgz5thZ7hH/uohA==",
       "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",
-      "resolved": "https://npm.sinequa.com/vary/-/vary-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "dev": true,
       "license": "MIT",
@@ -11306,7 +11306,7 @@
     },
     "node_modules/vite": {
       "version": "8.0.6",
-      "resolved": "https://npm.sinequa.com/vite/-/vite-8.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.6.tgz",
       "integrity": "sha512-jeOXoY6N8rOfit/mZADMd0misLqjRdWBB3/S23ZQNuPcbVsfMBJutWD8b4ftdczMOsNyMBnKro0Z1Kt0HIqq5Q==",
       "dev": true,
       "license": "MIT",
@@ -11384,7 +11384,7 @@
     },
     "node_modules/vite/node_modules/lightningcss": {
       "version": "1.32.0",
-      "resolved": "https://npm.sinequa.com/lightningcss/-/lightningcss-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
@@ -11414,7 +11414,7 @@
     },
     "node_modules/vite/node_modules/lightningcss-darwin-arm64": {
       "version": "1.32.0",
-      "resolved": "https://npm.sinequa.com/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
       "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
       "cpu": [
         "arm64"
@@ -11435,7 +11435,7 @@
     },
     "node_modules/vite/node_modules/lightningcss-darwin-x64": {
       "version": "1.32.0",
-      "resolved": "https://npm.sinequa.com/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
       "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
       "cpu": [
         "x64"
@@ -11456,7 +11456,7 @@
     },
     "node_modules/vite/node_modules/lightningcss-freebsd-x64": {
       "version": "1.32.0",
-      "resolved": "https://npm.sinequa.com/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
       "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
       "cpu": [
         "x64"
@@ -11477,7 +11477,7 @@
     },
     "node_modules/vite/node_modules/lightningcss-linux-arm-gnueabihf": {
       "version": "1.32.0",
-      "resolved": "https://npm.sinequa.com/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
       "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
       "cpu": [
         "arm"
@@ -11498,7 +11498,7 @@
     },
     "node_modules/vite/node_modules/lightningcss-linux-arm64-gnu": {
       "version": "1.32.0",
-      "resolved": "https://npm.sinequa.com/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
       "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
       "cpu": [
         "arm64"
@@ -11519,7 +11519,7 @@
     },
     "node_modules/vite/node_modules/lightningcss-linux-arm64-musl": {
       "version": "1.32.0",
-      "resolved": "https://npm.sinequa.com/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
@@ -11540,7 +11540,7 @@
     },
     "node_modules/vite/node_modules/lightningcss-linux-x64-gnu": {
       "version": "1.32.0",
-      "resolved": "https://npm.sinequa.com/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
       "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
       "cpu": [
         "x64"
@@ -11561,7 +11561,7 @@
     },
     "node_modules/vite/node_modules/lightningcss-linux-x64-musl": {
       "version": "1.32.0",
-      "resolved": "https://npm.sinequa.com/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
@@ -11582,7 +11582,7 @@
     },
     "node_modules/vite/node_modules/lightningcss-win32-arm64-msvc": {
       "version": "1.32.0",
-      "resolved": "https://npm.sinequa.com/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
       "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
       "cpu": [
         "arm64"
@@ -11603,7 +11603,7 @@
     },
     "node_modules/vite/node_modules/lightningcss-win32-x64-msvc": {
       "version": "1.32.0",
-      "resolved": "https://npm.sinequa.com/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
       "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
       "cpu": [
         "x64"
@@ -11624,7 +11624,7 @@
     },
     "node_modules/vite/node_modules/tinyglobby": {
       "version": "0.2.15",
-      "resolved": "https://npm.sinequa.com/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
       "dev": true,
       "license": "MIT",
@@ -11641,7 +11641,7 @@
     },
     "node_modules/watchpack": {
       "version": "2.4.4",
-      "resolved": "https://npm.sinequa.com/watchpack/-/watchpack-2.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.4.tgz",
       "integrity": "sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==",
       "dev": true,
       "license": "MIT",
@@ -11655,7 +11655,7 @@
     },
     "node_modules/wcwidth": {
       "version": "1.0.1",
-      "resolved": "https://npm.sinequa.com/wcwidth/-/wcwidth-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
       "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
       "license": "MIT",
       "dependencies": {
@@ -11664,7 +11664,7 @@
     },
     "node_modules/weak-lru-cache": {
       "version": "1.2.2",
-      "resolved": "https://npm.sinequa.com/weak-lru-cache/-/weak-lru-cache-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/weak-lru-cache/-/weak-lru-cache-1.2.2.tgz",
       "integrity": "sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==",
       "dev": true,
       "license": "MIT",
@@ -11672,13 +11672,13 @@
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
-      "resolved": "https://npm.sinequa.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
       "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
-      "resolved": "https://npm.sinequa.com/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
       "license": "MIT",
       "dependencies": {
@@ -11688,7 +11688,7 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "resolved": "https://npm.sinequa.com/which/-/which-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "license": "ISC",
       "dependencies": {
@@ -11703,7 +11703,7 @@
     },
     "node_modules/wrap-ansi": {
       "version": "6.2.0",
-      "resolved": "https://npm.sinequa.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
       "dev": true,
       "license": "MIT",
@@ -11719,7 +11719,7 @@
     "node_modules/wrap-ansi-cjs": {
       "name": "wrap-ansi",
       "version": "7.0.0",
-      "resolved": "https://npm.sinequa.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "license": "MIT",
       "dependencies": {
@@ -11736,7 +11736,7 @@
     },
     "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://npm.sinequa.com/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
       "engines": {
@@ -11745,13 +11745,13 @@
     },
     "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://npm.sinequa.com/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
     },
     "node_modules/wrap-ansi-cjs/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://npm.sinequa.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "license": "MIT",
       "engines": {
@@ -11760,7 +11760,7 @@
     },
     "node_modules/wrap-ansi-cjs/node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://npm.sinequa.com/string-width/-/string-width-4.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "license": "MIT",
       "dependencies": {
@@ -11774,7 +11774,7 @@
     },
     "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://npm.sinequa.com/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
       "dependencies": {
@@ -11786,7 +11786,7 @@
     },
     "node_modules/wrap-ansi/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://npm.sinequa.com/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
@@ -11796,14 +11796,14 @@
     },
     "node_modules/wrap-ansi/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://npm.sinequa.com/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://npm.sinequa.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
       "license": "MIT",
@@ -11813,7 +11813,7 @@
     },
     "node_modules/wrap-ansi/node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://npm.sinequa.com/string-width/-/string-width-4.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "license": "MIT",
@@ -11828,7 +11828,7 @@
     },
     "node_modules/wrap-ansi/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://npm.sinequa.com/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
@@ -11841,13 +11841,13 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://npm.sinequa.com/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "license": "ISC"
     },
     "node_modules/ws": {
       "version": "7.5.10",
-      "resolved": "https://npm.sinequa.com/ws/-/ws-7.5.10.tgz",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
       "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "license": "MIT",
       "engines": {
@@ -11868,7 +11868,7 @@
     },
     "node_modules/y18n": {
       "version": "5.0.8",
-      "resolved": "https://npm.sinequa.com/y18n/-/y18n-5.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "license": "ISC",
       "engines": {
@@ -11877,14 +11877,14 @@
     },
     "node_modules/yallist": {
       "version": "3.1.1",
-      "resolved": "https://npm.sinequa.com/yallist/-/yallist-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "2.8.3",
-      "resolved": "https://npm.sinequa.com/yaml/-/yaml-2.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "dev": true,
       "license": "ISC",
@@ -11900,7 +11900,7 @@
     },
     "node_modules/yargs": {
       "version": "17.7.2",
-      "resolved": "https://npm.sinequa.com/yargs/-/yargs-17.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "license": "MIT",
       "dependencies": {
@@ -11918,7 +11918,7 @@
     },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
-      "resolved": "https://npm.sinequa.com/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "license": "ISC",
       "engines": {
@@ -11927,7 +11927,7 @@
     },
     "node_modules/yargs/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://npm.sinequa.com/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
       "engines": {
@@ -11936,13 +11936,13 @@
     },
     "node_modules/yargs/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://npm.sinequa.com/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
     },
     "node_modules/yargs/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://npm.sinequa.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "license": "MIT",
       "engines": {
@@ -11951,7 +11951,7 @@
     },
     "node_modules/yargs/node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://npm.sinequa.com/string-width/-/string-width-4.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "license": "MIT",
       "dependencies": {
@@ -11965,7 +11965,7 @@
     },
     "node_modules/yargs/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://npm.sinequa.com/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
       "dependencies": {
@@ -11977,7 +11977,7 @@
     },
     "node_modules/yoctocolors-cjs": {
       "version": "2.1.3",
-      "resolved": "https://npm.sinequa.com/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
       "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
       "dev": true,
       "license": "MIT",
@@ -11990,7 +11990,7 @@
     },
     "node_modules/zod": {
       "version": "3.25.76",
-      "resolved": "https://npm.sinequa.com/zod/-/zod-3.25.76.tgz",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
@@ -12000,7 +12000,7 @@
     },
     "node_modules/zod-to-json-schema": {
       "version": "3.25.1",
-      "resolved": "https://npm.sinequa.com/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
       "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
       "dev": true,
       "license": "ISC",
@@ -12010,7 +12010,7 @@
     },
     "node_modules/zone.js": {
       "version": "0.15.1",
-      "resolved": "https://npm.sinequa.com/zone.js/-/zone.js-0.15.1.tgz",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.1.tgz",
       "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==",
       "license": "MIT"
     }


### PR DESCRIPTION
## Summary

- Replace all 836 `resolved` URLs in `package-lock.json` from `https://npm.sinequa.com` to `https://registry.npmjs.org`, as the Sinequa registry was causing installation failures
- Update the `integrity` hashes for `@sinequa/assistant@3.10.13` and `@sinequa/atomic@1.1.0`: their npmjs tarballs differ from the Sinequa registry ones (same versions, identical dependency metadata — verified)
- `@sinequa/atomic-angular@1.0.4` and `@sinequa/ui@1.0.0` are byte-identical on both registries (same integrity hashes)
- Note: `npm i --package-lock-only --registry=...` cannot perform this migration because npm never rewrites valid existing `resolved` entries — a direct replacement was required

## Test plan

- [x] All 836 occurrences of `npm.sinequa.com` removed (0 remaining)
- [x] Clean `npm ci` passes: 836 packages installed from `registry.npmjs.org`, all integrity checks OK
- [x] Lockfile not modified by the install (diff limited to the 836 URL lines + 2 integrity hashes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
